### PR TITLE
docs: audit and fix README inaccuracies across all packages

### DIFF
--- a/packages/blades/README.md
+++ b/packages/blades/README.md
@@ -24,8 +24,6 @@ A utility for rolling dice in [Forged in the Dark](https://bladesinthedark.com/)
 ```bash
 npm install @randsum/blades
 # or
-yarn add @randsum/blades
-# or
 bun add @randsum/blades
 ```
 
@@ -33,17 +31,17 @@ bun add @randsum/blades
 
 ```typescript
 import { roll } from "@randsum/blades"
-import type { BladesRollResult } from "@randsum/blades"
+import type { BladesResult } from "@randsum/blades"
 
 // Basic roll with dice pool
-const { outcome, result } = roll(2)
-console.log(outcome) // 'critical' | 'success' | 'partial' | 'failure'
+const { result } = roll(2)
+console.log(result) // 'critical' | 'success' | 'partial' | 'failure'
 
 // Different dice pool sizes
-roll(1) // Desperate position
-roll(2) // Risky position
-roll(3) // Controlled position
-roll(4) // Controlled with assistance
+roll(0) // Zero-dice roll (2d6, drop highest — desperate action)
+roll(1) // Single die
+roll(2) // Two-dice pool
+roll(3) // Three-dice pool
 ```
 
 ## API Reference
@@ -62,10 +60,10 @@ function roll(dicePool: number): BladesRollResult
 
 **Returns:**
 
-- `'critical'`: Rolled 6 on multiple dice (critical success)
-- `'success'`: Highest die was 4-6 (full success)
-- `'partial'`: Highest die was 1-3 (partial success/complication)
-- `'failure'`: No dice rolled (should not occur with valid input)
+- `'critical'`: Two or more dice showing 6 (only possible with dice pool > 0)
+- `'success'`: Highest die is 6
+- `'partial'`: Highest die is 4–5
+- `'failure'`: Highest die is 1–3
 
 **Result Interpretation:**
 

--- a/packages/fifth/README.md
+++ b/packages/fifth/README.md
@@ -33,13 +33,13 @@ const result = roll({ modifier: 5 })
 // Roll with advantage
 roll({
   modifier: 5,
-  rollingWith: "Advantage"
+  rollingWith: { advantage: true }
 })
 
 // Roll with disadvantage
 roll({
   modifier: -2,
-  rollingWith: "Disadvantage"
+  rollingWith: { disadvantage: true }
 })
 
 // Check against DC
@@ -57,19 +57,18 @@ function roll(options: FifthRollArgument): FifthRollResult
 
 **Options:**
 
-| Parameter     | Type                            | Description                       |
-| ------------- | ------------------------------- | --------------------------------- |
-| `modifier`    | `number`                        | Bonus/penalty to add to roll      |
-| `rollingWith` | `'Advantage' \| 'Disadvantage'` | Roll 2d20 and keep highest/lowest |
+| Parameter     | Type                                              | Description                       |
+| ------------- | ------------------------------------------------- | --------------------------------- |
+| `modifier`    | `number`                                          | Bonus/penalty to add to roll      |
+| `rollingWith` | `{ advantage?: boolean; disadvantage?: boolean }` | Roll 2d20 and keep highest/lowest |
 
 **Returns:**
 
 ```typescript
 interface FifthRollResult {
-  total: number
-  result: "natural_20" | "natural_1" | "standard"
-  details: { modifier: number }
-  rolls: RollRecord[]
+  total: number // Final total (d20 result + modifier)
+  result: number // Same as total
+  rolls: RollRecord[] // Full roll records
 }
 ```
 

--- a/packages/pbta/README.md
+++ b/packages/pbta/README.md
@@ -26,8 +26,6 @@ Works with any PbtA game including Dungeon World, Monster of the Week, Apocalyps
 ```bash
 npm install @randsum/pbta
 # or
-yarn add @randsum/pbta
-# or
 bun add @randsum/pbta
 ```
 

--- a/packages/roller/README.md
+++ b/packages/roller/README.md
@@ -56,8 +56,9 @@ The main function accepts numbers, notation strings, or options objects.
 const result = roll("2d6+3")
 
 result.total // Final total after all modifiers
-result.rolls // Array of individual roll results
-result.description // Human-readable description
+result.result // Array of individual die values
+result.rolls // Full roll records with modifier history
+result.error // null on success, RandsumError on failure
 ```
 
 ### Notation Reference

--- a/packages/root-rpg/README.md
+++ b/packages/root-rpg/README.md
@@ -24,8 +24,6 @@ A small collection of utilities for [Root RPG](https://magpiegames.com/collectio
 ```bash
 npm install @randsum/root-rpg
 # or
-yarn add @randsum/root-rpg
-# or
 bun add @randsum/root-rpg
 ```
 
@@ -33,16 +31,15 @@ bun add @randsum/root-rpg
 
 ```typescript
 import { roll } from "@randsum/root-rpg"
-import type { RootRpgRollResult } from "@randsum/root-rpg"
+import type { RootRpgResult } from "@randsum/root-rpg"
 
-// Basic roll with modifier
-const { outcome, roll, result } = roll(2)
-// outcome: 'Strong Hit' | 'Weak Hit' | 'Miss'
-// roll: numeric total, result: detailed roll information
+// Basic roll with bonus
+const { result, total } = roll(2)
+// result: 'Strong Hit' | 'Weak Hit' | 'Miss'
+// total: numeric total (2d6 + bonus)
 
 // Type-safe result handling
-const { outcome } = roll(0)
-switch (outcome) {
+switch (result) {
   case "Strong Hit":
     // 10 or higher
     break
@@ -66,10 +63,7 @@ function roll(bonus: number): RootRpgRollResult
 ```
 
 ```typescript
-type RootResult = RootStrongHit | RootWeakHit | RootMiss
-type RootStrongHit = "Strong Hit"
-type RootWeakHit = "Weak Hit"
-type RootMiss = "Miss"
+type RootRpgResult = "Strong Hit" | "Weak Hit" | "Miss"
 ```
 
 ## Related Packages

--- a/packages/salvageunion/README.md
+++ b/packages/salvageunion/README.md
@@ -14,7 +14,7 @@
 
 A type-safe implementation of [Salvage Union](https://www.geargrindergames.com/salvage-union) dice rolling mechanics that supports:
 
-- 🎲 Standard 2d10 rolls with modifiers
+- 🎲 Standard 1d20 rolls against result tables
 - 🎯 Automatic outcome determination
 - 📊 Built-in roll tables
 - 🔒 Full TypeScript support
@@ -25,8 +25,6 @@ A type-safe implementation of [Salvage Union](https://www.geargrindergames.com/s
 ```bash
 npm install @randsum/salvageunion
 # or
-yarn add @randsum/salvageunion
-# or
 bun add @randsum/salvageunion
 ```
 
@@ -34,34 +32,22 @@ bun add @randsum/salvageunion
 
 ```typescript
 import { roll } from "@randsum/salvageunion"
-import type { SalvageUnionTableResult } from "@randsum/salvageunion"
+import type { SalvageUnionRollRecord } from "@randsum/salvageunion"
 
-// Basic roll with default table
-const result = roll()
-// Returns table result with hit type, label, description, and roll value
+// Basic roll with default table (Core Mechanic)
+const { result } = roll()
+// result.label: human-readable outcome label
+// result.description: outcome description
+// result.roll: d20 value (1-20)
 
 // Roll with specific table
-const result = roll("Morale")
+const { result: moraleResult } = roll("Morale")
 
 // Type-safe result handling
-const { hit, label, description, roll } = roll("Core Mechanic")
-switch (hit) {
-  case "Nailed It":
-    // 20
-    break
-  case "Success":
-    // 11-19
-    break
-  case "Tough Choice":
-    // 6-10
-    break
-  case "Failure":
-    // 2-5
-    break
-  case "Cascade Failure":
-    // 1
-    break
-}
+const { result: coreResult } = roll("Core Mechanic")
+console.log(coreResult.label) // e.g. "Nailed It"
+console.log(coreResult.description) // e.g. outcome details
+console.log(coreResult.roll) // d20 result (1-20)
 ```
 
 ## API Reference
@@ -71,7 +57,11 @@ switch (hit) {
 Makes a d20 roll following Salvage Union rules, returning a table result object with hit type, label, description, and roll value.
 
 ```typescript
-function roll(tableName?: SalvageUnionTableName): SalvageUnionTableResult
+function roll(tableName?: SalvageUnionTableName): {
+  total: number
+  result: SalvageUnionRollRecord
+  rolls: RollRecord[]
+}
 ```
 
 ### Roll Tables


### PR DESCRIPTION
## Summary

- **blades**: fix import name (`BladesRollResult` → `BladesResult`), fix destructuring (no `outcome` field exists), fix result threshold descriptions (`success` = die is 6, `partial` = die is 4–5, `failure` = die is 1–3), remove `yarn add`
- **fifth**: fix `rollingWith` type (was `"Advantage"` string, is actually `{ advantage: true }` object), remove fabricated `result` union type (`natural_20`/`natural_1`/`standard` doesn't exist — result is `number`)
- **root-rpg**: fix import name (`RootRpgRollResult` → `RootRpgResult`), fix destructuring (no `outcome`/`roll` fields — use `result.result` and `result.total`), simplify type definition to match actual export
- **salvageunion**: fix die type (`2d10` → `1d20`), fix import name (`SalvageUnionTableResult` → `SalvageUnionRollRecord`), fix destructuring (result fields nested under `.result`, no `hit` field), update return type signature
- **roller**: remove non-existent `result.description`, document `result.result` (die values array) and `result.error`
- **pbta, blades, root-rpg, salvageunion**: remove `yarn add` (project uses bun/npm)

## Test plan

- [ ] All code examples in READMEs match actual TypeScript types in source
- [ ] No fabricated type names or field names remain

🤖 Generated with [Claude Code](https://claude.com/claude-code)