### PR TITLE
docs: refresh copy and site UI across packages and docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 <div align="center">
   <img width="150" height="150" src="https://raw.githubusercontent.com/RANDSUM/randsum/refs/heads/main/icon.webp" alt="Randsum Logo. A Dotted D6 rolled a 6 with the dots arranged to look like an R.">
   <h1>Randsum</h1>
-  <h3>A comprehensive dice rolling monorepo ecosystem for rolling dice and playing games.</h3>
+  <h3>A zero-dependency dice engine with expressive notation, built for developers who take their dice seriously.</h3>
 
 [![License](https://img.shields.io/npm/l/randsum)](https://github.com/RANDSUM/randsum/blob/main/LICENSE)
 [![CI Status](https://github.com/RANDSUM/randsum/workflows/CI/badge.svg)](https://github.com/RANDSUM/randsum/actions)

--- a/apps/site/astro.config.mjs
+++ b/apps/site/astro.config.mjs
@@ -32,7 +32,8 @@ export default defineConfig({
           items: [
             { label: 'Introduction', slug: 'getting-started/introduction' },
             { label: 'Installation', slug: 'getting-started/installation' },
-            { label: 'Quick Start', slug: 'getting-started/quick-start' }
+            { label: 'Quick Start', slug: 'getting-started/quick-start' },
+            { label: 'FAQ', slug: 'getting-started/faq' }
           ]
         },
         {
@@ -44,7 +45,16 @@ export default defineConfig({
           ]
         },
         {
-          label: 'Packages',
+          label: 'Guides',
+          items: [
+            { label: 'Error Handling', slug: 'guides/error-handling' },
+            { label: 'Recipes', slug: 'guides/recipes' },
+            { label: 'Custom Game Packages', slug: 'guides/custom-game-packages' },
+            { label: 'Testing', slug: 'guides/testing' }
+          ]
+        },
+        {
+          label: 'Core',
           items: [
             { label: 'Overview', slug: 'packages/overview' },
             { label: '@randsum/roller', slug: 'packages/roller' }
@@ -58,28 +68,23 @@ export default defineConfig({
             { label: 'Blades in the Dark', slug: 'games/blades' },
             { label: 'Daggerheart', slug: 'games/daggerheart' },
             { label: 'D&D 5e', slug: 'games/fifth' },
-            {
-              label: 'Powered by the Apocalypse',
-              slug: 'games/pbta'
-            },
+            { label: 'Powered by the Apocalypse', slug: 'games/pbta' },
             { label: 'Root RPG', slug: 'games/root-rpg' },
             { label: 'Salvage Union', slug: 'games/salvageunion' }
           ]
         },
         {
-          label: 'Tools',
+          label: 'LLM Skill',
           items: [
-            { label: 'Discord Bot', slug: 'tools/discord-bot' },
-            {
-              label: 'LLM Skill',
-              items: [
-                { label: 'Overview', slug: 'tools/skill' },
-                { label: 'Skill Definition', slug: 'tools/skill/dice-rolling' },
-                { label: 'Notation Reference', slug: 'tools/skill/notation' },
-                { label: 'Game Systems', slug: 'tools/skill/game-systems' }
-              ]
-            }
+            { label: 'Overview', slug: 'tools/skill' },
+            { label: 'Skill Definition', slug: 'tools/skill/dice-rolling' },
+            { label: 'Notation Reference', slug: 'tools/skill/notation' },
+            { label: 'Game Systems', slug: 'tools/skill/game-systems' }
           ]
+        },
+        {
+          label: 'Tools',
+          items: [{ label: 'Discord Bot', slug: 'tools/discord-bot' }]
         }
       ]
     }),

--- a/apps/site/astro.config.mjs
+++ b/apps/site/astro.config.mjs
@@ -23,11 +23,6 @@ export default defineConfig({
           icon: 'github',
           label: 'GitHub',
           href: 'https://github.com/RANDSUM/randsum'
-        },
-        {
-          icon: 'discord',
-          label: 'Discord',
-          href: 'https://discord.gg/randsum'
         }
       ],
       customCss: ['./src/styles/custom.css'],

--- a/apps/site/src/content/docs/getting-started/faq.mdx
+++ b/apps/site/src/content/docs/getting-started/faq.mdx
@@ -80,8 +80,8 @@ import { roll } from '@randsum/roller'
 function seededRandom(seed: number) {
   let s = seed
   return () => {
-    s = (s * 1664525 + 1013904223) & 0xffffffff
-    return (s >>> 0) / 0xffffffff
+    s = (s * 1664525 + 1013904223) >>> 0
+    return s / 0x100000000
   }
 }
 

--- a/apps/site/src/content/docs/getting-started/faq.mdx
+++ b/apps/site/src/content/docs/getting-started/faq.mdx
@@ -8,6 +8,8 @@ description: Common questions about RANDSUM
 RANDSUM follows a never-throw design — errors are returned as values rather than raised as exceptions. This makes error handling explicit and composable without try/catch blocks.
 
 ```typescript
+import { roll } from '@randsum/roller'
+
 const result = roll('invalid notation')
 
 if (result.error) {
@@ -38,12 +40,14 @@ console.log(result.result) // 'critical' | 'success' | 'partial' | 'failure'
 Every `roll()` result includes a `rolls` array of `RollRecord` objects — one per dice group. Each record contains the individual die values before and after modifiers.
 
 ```typescript
+import { roll } from '@randsum/roller'
+
 const result = roll('4d6L')
 
 // Access all roll records
 result.rolls.forEach(record => {
-  console.log(record.result)         // Individual die values after modifiers
-  console.log(record.initialRolls)   // Individual die values before modifiers
+  console.log(record.modifierHistory.modifiedRolls)  // die values after modifiers
+  console.log(record.rolls)                          // die values before modifiers
 })
 ```
 
@@ -67,14 +71,21 @@ The reroll modifier has a built-in attempt limit (`MAX_REROLL_ATTEMPTS = 99`). I
 
 ## Can I seed the random number generator?
 
-Yes — pass a `randomFn` in the `RollConfig` argument. RANDSUM exports `createSeededRandom` for deterministic testing:
+Yes — pass a `randomFn` in the `RollConfig` argument. Any function that returns a number in `[0, 1)` works. Here is a simple seeded random function you can use:
 
 ```typescript
 import { roll } from '@randsum/roller'
-import { createSeededRandom } from '@randsum/roller'
 
-const seeded = createSeededRandom(42)
-const result = roll('4d6L', { randomFn: seeded })
+// Simple seeded random (linear congruential generator)
+function seededRandom(seed: number) {
+  let s = seed
+  return () => {
+    s = (s * 1664525 + 1013904223) & 0xffffffff
+    return (s >>> 0) / 0xffffffff
+  }
+}
+
+const result = roll('4d6L', { randomFn: seededRandom(42) })
 // Same result every time with seed 42
 ```
 

--- a/apps/site/src/content/docs/getting-started/faq.mdx
+++ b/apps/site/src/content/docs/getting-started/faq.mdx
@@ -1,0 +1,94 @@
+---
+title: FAQ
+description: Common questions about RANDSUM
+---
+
+## Why doesn't `roll()` throw?
+
+RANDSUM follows a never-throw design — errors are returned as values rather than raised as exceptions. This makes error handling explicit and composable without try/catch blocks.
+
+```typescript
+const result = roll('invalid notation')
+
+if (result.error) {
+  // Handle the error — result.total is undefined here
+  console.error(result.error.message)
+  return
+}
+
+// Safe to use result.total here
+console.log(result.total)
+```
+
+See [Error Handling](/guides/error-handling/) for the full pattern.
+
+## How do I roll a 0-dice Blades pool?
+
+Pass `0` to `roll()` from `@randsum/blades`. A 0-dice pool represents a **desperate position** in Blades in the Dark — the system rolls 2d6 and keeps the lowest die.
+
+```typescript
+import { roll } from '@randsum/blades'
+
+const result = roll(0) // Rolls 2d6, keeps lowest
+console.log(result.result) // 'critical' | 'success' | 'partial' | 'failure'
+```
+
+## How do I access individual die results?
+
+Every `roll()` result includes a `rolls` array of `RollRecord` objects — one per dice group. Each record contains the individual die values before and after modifiers.
+
+```typescript
+const result = roll('4d6L')
+
+// Access all roll records
+result.rolls.forEach(record => {
+  console.log(record.result)         // Individual die values after modifiers
+  console.log(record.initialRolls)   // Individual die values before modifiers
+})
+```
+
+## Can I use RANDSUM in the browser?
+
+Yes. `@randsum/roller` has zero runtime dependencies and uses only standard JavaScript — no Node.js built-ins. It works in any environment that runs modern JS: browsers, Deno, Bun, Edge functions, and Node.js 18+.
+
+## What runtimes are supported?
+
+| Runtime | Supported |
+|---|---|
+| Node.js 18+ | Yes |
+| Bun 1.0+ | Yes |
+| Deno | Yes |
+| Browser (ESM) | Yes |
+| Edge functions (Cloudflare, Vercel) | Yes |
+
+## How does `reroll` prevent infinite loops?
+
+The reroll modifier has a built-in attempt limit (`MAX_REROLL_ATTEMPTS = 99`). If the reroll condition can never be satisfied (e.g., rerolling all results on a d1), RANDSUM stops after the limit and returns the last rolled value. It will never hang.
+
+## Can I seed the random number generator?
+
+Yes — pass a `randomFn` in the `RollConfig` argument. RANDSUM exports `createSeededRandom` for deterministic testing:
+
+```typescript
+import { roll } from '@randsum/roller'
+import { createSeededRandom } from '@randsum/roller'
+
+const seeded = createSeededRandom(42)
+const result = roll('4d6L', { randomFn: seeded })
+// Same result every time with seed 42
+```
+
+See [Testing](/guides/testing/) for more patterns.
+
+## Do the game packages work together?
+
+No — and by design. Game packages depend only on `@randsum/roller`. They never depend on each other. Install only the packages your application needs.
+
+## What's the difference between `drop` and `keep`?
+
+Both select a subset of dice — they approach it from opposite directions:
+
+- `drop: { lowest: 1 }` — removes 1 die, keeps the rest
+- `keep: { highest: 3 }` — keeps 3 dice, removes the rest
+
+On a `4d6` roll, `4d6L` (drop lowest 1) and `keep: { highest: 3 }` produce identical results.

--- a/apps/site/src/content/docs/getting-started/installation.mdx
+++ b/apps/site/src/content/docs/getting-started/installation.mdx
@@ -113,4 +113,4 @@ const result = roll('2d6')
 console.log(result.total) // Sum of 2d6
 ```
 
-If this runs without errors, you are ready to go. Head to the [Quick Start](/getting-started/quick-start/) guide to learn the basics.
+If this runs without errors, installation is complete. See the [Quick Start](/getting-started/quick-start/) guide to learn the basics.

--- a/apps/site/src/content/docs/getting-started/introduction.mdx
+++ b/apps/site/src/content/docs/getting-started/introduction.mdx
@@ -1,9 +1,9 @@
 ---
 title: Introduction
-description: Welcome to RANDSUM - a modular TypeScript dice rolling ecosystem for tabletop RPGs
+description: Welcome to RANDSUM — a zero-dependency dice engine with expressive notation
 ---
 
-RANDSUM is a modular TypeScript dice rolling ecosystem built for tabletop RPGs. Whether you are building a simple dice roller, a full virtual tabletop, or integrating dice mechanics into a Discord bot, RANDSUM provides the foundation you need.
+RANDSUM is a zero-dependency dice engine with expressive notation, built for developers who take their dice seriously.
 
 ## Why RANDSUM?
 

--- a/apps/site/src/content/docs/getting-started/quick-start.mdx
+++ b/apps/site/src/content/docs/getting-started/quick-start.mdx
@@ -1,6 +1,6 @@
 ---
 title: Quick Start
-description: Get rolling dice in minutes with RANDSUM
+description: Learn the basics of rolling dice with @randsum/roller
 ---
 
 This guide walks you through the basics of using `@randsum/roller` to roll dice in your application.

--- a/apps/site/src/content/docs/guides/custom-game-packages.mdx
+++ b/apps/site/src/content/docs/guides/custom-game-packages.mdx
@@ -1,0 +1,205 @@
+---
+title: Custom Game Packages
+description: Build your own game package using the createGameRoll factory
+---
+
+import { Aside } from '@astrojs/starlight/components'
+
+## When to use this
+
+Use `createGameRoll` when you need to:
+
+- Map game-specific input (stat blocks, roll modes) to dice roll parameters
+- Interpret a numeric total into a game outcome (`'hit' | 'miss'`, `'strong_hit' | 'weak_hit'`, etc.)
+- Return a fully typed result that your application or library can consume without casting
+
+## `createGameRoll`
+
+`createGameRoll` is a factory that wires together three hooks — validate, convert, interpret — and returns a ready-to-call roll function.
+
+```typescript
+import { createGameRoll } from '@randsum/roller'
+
+const myRoll = createGameRoll<TInput, TResult, TDetails>({
+  validate: (input) => { /* throw if invalid */ },
+  toRollOptions: (input) => ({ sides: 6, quantity: 2 }),
+  interpretResult: (input, total, rolls, fullResult) => { /* return TResult */ }
+})
+```
+
+### `validate`
+
+Called first with the raw input. Throw here if the input is invalid — the error will propagate to the caller as a thrown exception.
+
+`@randsum/roller` exports these validation helpers:
+
+```typescript
+import {
+  validateFinite,      // value is a finite number
+  validateInteger,     // value is an integer
+  validateRange,       // value is within min/max bounds
+  validateNonNegative, // value >= 0
+  validateGreaterThan, // value > threshold
+  validateLessThan     // value < threshold
+} from '@randsum/roller'
+```
+
+Each helper takes the value, a label string, and (for range helpers) bounds:
+
+```typescript
+validate: (input) => {
+  validateFinite(input.modifier, 'modifier')
+  validateRange(input.modifier, -10, 10, 'modifier')
+}
+```
+
+<Aside type="caution">
+  Validation errors throw directly. Wrap the call in a try/catch if you need to handle them gracefully rather than letting them propagate.
+</Aside>
+
+### `toRollOptions`
+
+Converts validated input into a `RollOptions` object (or an array of them for multi-pool rolls). This is where you express game mechanics as dice parameters.
+
+```typescript
+toRollOptions: (input) => ({
+  sides: 20,
+  quantity: input.advantage ? 2 : 1,
+  modifiers: {
+    drop: input.advantage ? { lowest: 1 } : undefined,
+    plus: input.modifier
+  }
+})
+```
+
+### `interpretResult`
+
+Receives the resolved total, the individual roll records, and the full `RollerRollResult`. Return your game-specific `TResult` here.
+
+```typescript
+interpretResult: (input, total, rolls, fullResult) => {
+  if (total >= 10) return 'strong_hit'
+  if (total >= 7)  return 'weak_hit'
+  return 'miss'
+}
+```
+
+## Minimal example: a 2d6+stat system
+
+A PbtA-style roll that maps 2d6 + stat to a three-outcome result:
+
+```typescript
+import { createGameRoll, validateFinite, validateRange } from '@randsum/roller'
+import type { GameRollResult, RollRecord } from '@randsum/roller'
+
+type PbtaStat = number
+type PbtaOutcome = 'strong_hit' | 'weak_hit' | 'miss'
+
+const rollPbta = createGameRoll<PbtaStat, PbtaOutcome>({
+  validate: (stat) => {
+    validateFinite(stat, 'stat')
+    validateRange(stat, -3, 3, 'stat')
+  },
+  toRollOptions: (stat) => ({
+    quantity: 2,
+    sides: 6,
+    modifiers: { plus: stat }
+  }),
+  interpretResult: (_input, total) => {
+    if (total >= 10) return 'strong_hit'
+    if (total >= 7)  return 'weak_hit'
+    return 'miss'
+  }
+})
+
+// Usage
+const result = rollPbta(2)
+// result.result => 'strong_hit' | 'weak_hit' | 'miss'
+// result.total  => 2d6 + 2
+// result.rolls  => RollRecord[]
+```
+
+## Adding details (`computeDetails`)
+
+Use the optional `computeDetails` hook to attach structured metadata to the result. Pass `TDetails` as the third generic argument.
+
+```typescript
+type PbtaDetails = {
+  diceValues: number[]
+  wasModified: boolean
+}
+
+const rollPbta = createGameRoll<PbtaStat, PbtaOutcome, PbtaDetails>({
+  validate: (stat) => {
+    validateFinite(stat, 'stat')
+    validateRange(stat, -3, 3, 'stat')
+  },
+  toRollOptions: (stat) => ({
+    quantity: 2,
+    sides: 6,
+    modifiers: { plus: stat }
+  }),
+  interpretResult: (_input, total) => {
+    if (total >= 10) return 'strong_hit'
+    if (total >= 7)  return 'weak_hit'
+    return 'miss'
+  },
+  computeDetails: (_input, total, rolls) => ({
+    diceValues: rolls.flatMap(r => r.rolls),
+    wasModified: rolls.some(r => r.total !== r.rolls.reduce((a, b) => a + b, 0))
+  })
+})
+
+// result.details => PbtaDetails
+```
+
+## `createMultiRollGameRoll`
+
+Use `createMultiRollGameRoll` when your game requires multiple distinct, named dice rolls — for example, a Hope die and a Fear die that are compared against each other.
+
+Each entry in `toRollOptions` takes a `key` string. After rolling, `interpretResult` receives a `Map<string, RollRecord>` keyed by those strings.
+
+```typescript
+import { createMultiRollGameRoll, validateFinite, validateRange } from '@randsum/roller'
+import type { RollRecord, RollerRollResult } from '@randsum/roller'
+
+type DualDiceInput = { modifier: number }
+type DualDiceResult = 'dominant_a' | 'dominant_b' | 'tied'
+
+const rollDual = createMultiRollGameRoll<DualDiceInput, DualDiceResult>({
+  validate: (input) => {
+    validateFinite(input.modifier, 'modifier')
+    validateRange(input.modifier, -10, 10, 'modifier')
+  },
+  toRollOptions: (_input) => [
+    { sides: 12, key: 'a' },
+    { sides: 12, key: 'b' }
+  ],
+  interpretResult: (input, rollResult, rollsByKey) => {
+    const rollA = rollsByKey.get('a')
+    const rollB = rollsByKey.get('b')
+
+    if (!rollA || !rollB) throw new Error('Missing expected dice')
+
+    let result: DualDiceResult
+    if (rollA.total > rollB.total)      result = 'dominant_a'
+    else if (rollB.total > rollA.total) result = 'dominant_b'
+    else                                result = 'tied'
+
+    return { result, total: rollResult.total + input.modifier }
+  }
+})
+
+// Usage
+const result = rollDual({ modifier: 2 })
+// result.result => 'dominant_a' | 'dominant_b' | 'tied'
+// result.total  => sum of both dice + 2
+```
+
+<Aside>
+  In `createMultiRollGameRoll`, `interpretResult` returns an object `{ result, details?, total? }` rather than returning the result value directly. The optional `total` overrides the summed total from the roll engine; the optional `details` is attached to the final `GameRollResult`.
+</Aside>
+
+## Bundle size note
+
+Keep your custom package under 7 KB (gzipped) — the same limit enforced for all official `@randsum` game packages.

--- a/apps/site/src/content/docs/guides/custom-game-packages.mdx
+++ b/apps/site/src/content/docs/guides/custom-game-packages.mdx
@@ -53,9 +53,26 @@ validate: (input) => {
 }
 ```
 
+`validateGreaterThan` and `validateLessThan` take `(value, threshold, name)`:
+
+```typescript
+// validateGreaterThan and validateLessThan take (value, threshold, name)
+validateGreaterThan(input.count, 0, 'count')  // must be > 0
+validateLessThan(input.count, 100, 'count')   // must be < 100
+```
+
 <Aside type="caution">
   Validation errors throw directly. Wrap the call in a try/catch if you need to handle them gracefully rather than letting them propagate.
 </Aside>
+
+```typescript
+// Wrap in try/catch to handle validation errors gracefully
+try {
+  const result = rollPbta({ stat: 999 })
+} catch (err) {
+  if (err instanceof Error) console.error(err.message)
+}
+```
 
 ### `toRollOptions`
 
@@ -126,7 +143,7 @@ Use the optional `computeDetails` hook to attach structured metadata to the resu
 ```typescript
 type PbtaDetails = {
   diceValues: number[]
-  wasModified: boolean
+  statBonus: number
 }
 
 const rollPbta = createGameRoll<PbtaStat, PbtaOutcome, PbtaDetails>({
@@ -144,9 +161,9 @@ const rollPbta = createGameRoll<PbtaStat, PbtaOutcome, PbtaDetails>({
     if (total >= 7)  return 'weak_hit'
     return 'miss'
   },
-  computeDetails: (_input, total, rolls) => ({
+  computeDetails: (input, _total, rolls) => ({
     diceValues: rolls.flatMap(r => r.rolls),
-    wasModified: rolls.some(r => r.total !== r.rolls.reduce((a, b) => a + b, 0))
+    statBonus: input
   })
 })
 

--- a/apps/site/src/content/docs/guides/error-handling.mdx
+++ b/apps/site/src/content/docs/guides/error-handling.mdx
@@ -1,0 +1,115 @@
+---
+title: Error Handling
+description: How to handle errors with RANDSUM's never-throw design
+---
+
+import { Aside } from '@astrojs/starlight/components'
+
+RANDSUM uses a **never-throw** design. The `roll()` function never raises an exception — errors are returned as values in the result object.
+
+<Aside type="tip">
+  This design means you never need try/catch around `roll()` calls. Error handling is always explicit.
+</Aside>
+
+## The `result.error` pattern
+
+When `roll()` encounters an error, it returns an object with an `error` property instead of a `total`. Check for `result.error` before using `result.total`:
+
+```typescript
+import { roll } from '@randsum/roller'
+
+const result = roll(userInput)
+
+if (result.error) {
+  // result.total is undefined — do not use it
+  console.error(result.error.message)
+  return
+}
+
+// TypeScript narrows the type here — result.total is number
+console.log(result.total)
+```
+
+## When errors occur
+
+`roll()` returns an error when:
+
+- The notation string is syntactically invalid (`'4dX'`, `'not dice'`)
+- The options object has invalid values (e.g., `sides: 0`, `quantity: -1`)
+- A modifier receives an out-of-range argument
+
+Valid-but-unusual inputs (like `roll(1)` for a single-sided die) are not errors.
+
+## Validating before rolling
+
+If you want to check notation before passing it to `roll()`, use `validateNotation()` or the `isDiceNotation()` type guard:
+
+### `isDiceNotation` — type guard
+
+```typescript
+import { isDiceNotation, roll } from '@randsum/roller'
+
+function rollUserInput(input: string) {
+  if (!isDiceNotation(input)) {
+    return { error: 'Not valid dice notation' }
+  }
+
+  // input is now typed as DiceNotation
+  return roll(input)
+}
+```
+
+### `validateNotation` — parsed result
+
+```typescript
+import { validateNotation } from '@randsum/roller'
+
+const validation = validateNotation('4d6L')
+
+if (!validation.valid) {
+  console.error(validation.error.message)
+} else {
+  // validation.options contains the structured roll options
+  console.log(validation.options)
+}
+```
+
+## Game package errors
+
+Game packages (like `@randsum/blades`, `@randsum/fifth`) follow the same pattern. Their `roll()` functions also return errors as values:
+
+```typescript
+import { roll } from '@randsum/fifth'
+
+const result = roll({ modifier: 999 }) // modifier out of range
+
+if (result.error) {
+  console.error(result.error.message) // 'modifier must be between -30 and 30'
+}
+```
+
+## TypeScript narrowing
+
+After a `result.error` check, TypeScript automatically narrows the result type:
+
+```typescript
+import { roll } from '@randsum/roller'
+
+const result = roll('2d6')
+
+// Before check: result.total is number | undefined
+result.total // number | undefined
+
+if (result.error) {
+  result.total // undefined (TypeScript knows)
+  return
+}
+
+result.total // number (TypeScript knows this is safe)
+```
+
+## Production checklist
+
+- Always check `result.error` when rolling user-provided input (form fields, chat commands, API parameters)
+- Internal rolls with hardcoded notation can skip the check — `roll('2d6')` will never produce an error
+- Use `isDiceNotation()` to validate strings at system boundaries (user input, external APIs)

--- a/apps/site/src/content/docs/guides/error-handling.mdx
+++ b/apps/site/src/content/docs/guides/error-handling.mdx
@@ -13,7 +13,7 @@ RANDSUM uses a **never-throw** design. The `roll()` function never raises an exc
 
 ## The `result.error` pattern
 
-When `roll()` encounters an error, it returns an object with an `error` property instead of a `total`. Check for `result.error` before using `result.total`:
+When `roll()` encounters an error, it returns an object where `result.error` is set and `result.total` is `0`. Check for `result.error` before using `result.total`:
 
 ```typescript
 import { roll } from '@randsum/roller'

--- a/apps/site/src/content/docs/guides/error-handling.mdx
+++ b/apps/site/src/content/docs/guides/error-handling.mdx
@@ -21,7 +21,7 @@ import { roll } from '@randsum/roller'
 const result = roll(userInput)
 
 if (result.error) {
-  // result.total is undefined — do not use it
+  // result.total is 0 — do not use it
   console.error(result.error.message)
   return
 }
@@ -74,38 +74,23 @@ if (!validation.valid) {
 }
 ```
 
-## Game package errors
+## Checking the error value
 
-Game packages (like `@randsum/blades`, `@randsum/fifth`) follow the same pattern. Their `roll()` functions also return errors as values:
-
-```typescript
-import { roll } from '@randsum/fifth'
-
-const result = roll({ modifier: 999 }) // modifier out of range
-
-if (result.error) {
-  console.error(result.error.message) // 'modifier must be between -30 and 30'
-}
-```
-
-## TypeScript narrowing
-
-After a `result.error` check, TypeScript automatically narrows the result type:
+`result.error` is typed as `RandsumError | null`. On success it is `null`; on error it is a `RandsumError`. `result.total` is always a `number` — on error its value is `0`.
 
 ```typescript
 import { roll } from '@randsum/roller'
 
 const result = roll('2d6')
 
-// Before check: result.total is number | undefined
-result.total // number | undefined
-
-if (result.error) {
-  result.total // undefined (TypeScript knows)
+if (result.error !== null) {
+  // result.error is RandsumError — inspect result.error.message
+  // result.total is 0 — do not use it for game logic
   return
 }
 
-result.total // number (TypeScript knows this is safe)
+// result.error is null — safe to use result.total
+console.log(result.total)
 ```
 
 ## Production checklist

--- a/apps/site/src/content/docs/guides/recipes.mdx
+++ b/apps/site/src/content/docs/guides/recipes.mdx
@@ -1,0 +1,144 @@
+---
+title: Recipes
+description: Short, focused code patterns for common RANDSUM use cases
+---
+
+Short solutions to common dice-rolling problems.
+
+## Seeded rolls
+
+Produce the same result every time — useful for replays, testing, or deterministic outcomes.
+
+```typescript
+import { roll } from '@randsum/roller'
+
+// Simple seeded random (linear congruential generator)
+function seededRandom(seed: number) {
+  let s = seed
+  return () => {
+    s = (s * 1664525 + 1013904223) >>> 0
+    return s / 0x100000000
+  }
+}
+
+const result = roll('4d6L', { randomFn: seededRandom(42) })
+// Same result every time with seed 42
+```
+
+## Combining multiple rolls into one total
+
+Pass multiple arguments to `roll()` — they are combined into a single `total`.
+
+```typescript
+import { roll } from '@randsum/roller'
+
+// Attack roll + damage roll
+const result = roll('1d20+5', '2d6+3')
+console.log(result.total) // d20+5 + 2d6+3, combined
+
+// Mix numbers, strings, and options objects
+const combined = roll(20, '2d6', { sides: 8, quantity: 1 })
+```
+
+## Advantage with arbitrary dice
+
+The drop modifier works on any die type — not just d20.
+
+```typescript
+import { roll } from '@randsum/roller'
+
+// Advantage on a d12 (Daggerheart-style)
+roll({ sides: 12, quantity: 2, modifiers: { drop: { lowest: 1 } } })
+
+// Disadvantage on 2d6
+roll({ sides: 6, quantity: 2, modifiers: { drop: { highest: 1 } } })
+
+// Advantage shorthand via notation
+roll('2d12H') // Roll 2d12, drop highest (disadvantage)
+roll('2d12L') // Roll 2d12, drop lowest  (advantage)
+```
+
+## Subtracting one roll from another
+
+Use the `arithmetic: 'subtract'` option on a roll group.
+
+```typescript
+import { roll } from '@randsum/roller'
+
+// 2d12 minus 1d6
+const result = roll(
+  { sides: 12, quantity: 2 },
+  { sides: 6, quantity: 1, arithmetic: 'subtract' }
+)
+```
+
+## Custom faces (non-numeric dice)
+
+Pass an array of strings or values as `sides` for dice with custom faces (Fate/Fudge dice, custom results).
+
+```typescript
+import { roll } from '@randsum/roller'
+
+// Fate dice: 4dF (−, ·, +)
+const fate = roll({
+  sides: ['+', '+', ' ', ' ', '-', '-'],
+  quantity: 4
+})
+console.log(fate.rolls[0].customResults) // Array of '+', ' ', or '-'
+```
+
+## Rolling and filtering results
+
+Roll several times and collect only the results you want.
+
+```typescript
+import { roll } from '@randsum/roller'
+
+// Roll 10d6, keep only 6s (counting successes manually)
+const results = Array.from({ length: 10 }, () => roll(6).total)
+const successes = results.filter(r => r === 6).length
+```
+
+Or use the `countSuccesses` modifier to do it in one call:
+
+```typescript
+import { roll } from '@randsum/roller'
+
+const result = roll({
+  sides: 6,
+  quantity: 10,
+  modifiers: { countSuccesses: { threshold: 4 } }
+})
+console.log(result.total) // Count of dice >= 4
+```
+
+## Generating a roll histogram
+
+Roll many times and count how often each total appears.
+
+```typescript
+import { roll } from '@randsum/roller'
+
+const histogram: Record<number, number> = {}
+
+for (let i = 0; i < 10000; i++) {
+  const { total } = roll('2d6')
+  histogram[total] = (histogram[total] ?? 0) + 1
+}
+
+console.log(histogram)
+// { '2': ~278, '7': ~1667, '12': ~278, ... }
+```
+
+## Using a crypto-quality random function
+
+Replace `Math.random` with `crypto.getRandomValues` for better entropy.
+
+```typescript
+import { roll } from '@randsum/roller'
+
+const cryptoRandom = (): number =>
+  crypto.getRandomValues(new Uint32Array(1))[0] / 2 ** 32
+
+const result = roll('2d6', { randomFn: cryptoRandom })
+```

--- a/apps/site/src/content/docs/guides/recipes.mdx
+++ b/apps/site/src/content/docs/guides/recipes.mdx
@@ -84,7 +84,7 @@ const fate = roll({
   sides: ['+', '+', ' ', ' ', '-', '-'],
   quantity: 4
 })
-console.log(fate.rolls[0].customResults) // Array of '+', ' ', or '-'
+console.log(fate.result) // e.g. ['+', '-', ' ', '+']
 ```
 
 ## Rolling and filtering results

--- a/apps/site/src/content/docs/guides/testing.mdx
+++ b/apps/site/src/content/docs/guides/testing.mdx
@@ -1,0 +1,190 @@
+---
+title: Testing
+description: How to write deterministic tests for code that uses RANDSUM
+---
+
+import { Tabs, TabItem } from '@astrojs/starlight/components'
+
+Rolling dice is inherently random, which makes testing tricky. RANDSUM provides a `randomFn` option on `roll()` so you can inject a deterministic random number generator and make your tests reproducible.
+
+## Seeded random
+
+The `roll()` function accepts an optional `RollConfig` object as its last argument. Pass a `randomFn` to replace the built-in RNG:
+
+```typescript
+import { roll } from '@randsum/roller'
+
+function seededRandom(seed: number) {
+  let s = seed
+  return () => {
+    s = (s * 1664525 + 1013904223) >>> 0
+    return s / 0x100000000
+  }
+}
+
+const rng = seededRandom(42)
+const result = roll('2d6', { randomFn: rng })
+// result.total is the same value every time this test runs
+```
+
+The `randomFn` must return a number in `[0, 1)` — the same contract as `Math.random()`. The LCG above (linear congruential generator) is simple and sufficient for tests.
+
+## Example: unit test with a known seed
+
+```typescript
+import { describe, expect, test } from 'bun:test'
+import { roll } from '@randsum/roller'
+
+function seededRandom(seed: number) {
+  let s = seed
+  return () => {
+    s = (s * 1664525 + 1013904223) >>> 0
+    return s / 0x100000000
+  }
+}
+
+describe('roll with seeded RNG', () => {
+  test('produces the same total for the same seed', () => {
+    const result1 = roll('2d6', { randomFn: seededRandom(42) })
+    const result2 = roll('2d6', { randomFn: seededRandom(42) })
+
+    expect(result1.total).toBe(result2.total)
+    expect(result1.result).toEqual(result2.result)
+  })
+
+  test('produces different totals for different seeds', () => {
+    const result1 = roll('1d20', { randomFn: seededRandom(1) })
+    const result2 = roll('1d20', { randomFn: seededRandom(999) })
+
+    // Not guaranteed to differ, but almost always will for different seeds
+    // Use this pattern only when you know the seed outputs differ
+    expect(result1.error).toBeNull()
+    expect(result2.error).toBeNull()
+  })
+})
+```
+
+## Property-based tests with fast-check
+
+Property-based testing runs your assertions against many randomly generated inputs rather than a single fixed example. Instead of checking "does `roll('2d6')` return 7?", you check "does `roll({ sides: S, quantity: Q })` always return a total between `Q` and `Q * S`?"
+
+`fast-check` is already included as a workspace dev dependency — no installation needed.
+
+```typescript
+import { describe, test } from 'bun:test'
+import fc from 'fast-check'
+import { roll } from '@randsum/roller'
+
+describe('roll property-based tests', () => {
+  test('total is always within the valid range for any sides and quantity', () => {
+    fc.assert(
+      fc.property(
+        fc.integer({ min: 1, max: 100 }), // sides
+        fc.integer({ min: 1, max: 20 }),  // quantity
+        (sides, quantity) => {
+          const result = roll({ sides, quantity })
+          return result.total >= quantity && result.total <= quantity * sides
+        }
+      )
+    )
+  })
+
+  test('result array length equals quantity', () => {
+    fc.assert(
+      fc.property(
+        fc.integer({ min: 1, max: 20 }), // sides
+        fc.integer({ min: 1, max: 10 }), // quantity
+        (sides, quantity) => {
+          const result = roll({ sides, quantity })
+          return result.result.length === quantity
+        }
+      )
+    )
+  })
+})
+```
+
+`fc.assert` throws if any generated input falsifies the property, and prints a minimal failing example to help you diagnose the issue.
+
+## Stress tests
+
+For boundary validation, a tight loop is often clearer than a property test:
+
+```typescript
+import { describe, expect, test } from 'bun:test'
+import { roll } from '@randsum/roller'
+
+describe('2d6 stress test', () => {
+  test('total is always between 2 and 12 across 9999 rolls', () => {
+    for (let i = 0; i < 9999; i++) {
+      const { total } = roll('2d6')
+      expect(total).toBeGreaterThanOrEqual(2)
+      expect(total).toBeLessThanOrEqual(12)
+    }
+  })
+})
+```
+
+This is especially useful for modifiers like `drop` or `reroll` where the valid output range is non-obvious.
+
+## Testing game packages
+
+Game package roll functions (for example, `roll` from `@randsum/fifth` or `@randsum/blades`) are created with `createGameRoll` and only accept their game-specific input type. They do not expose a `randomFn` parameter.
+
+To test game packages deterministically, test the underlying `roll()` from `@randsum/roller` with a seeded RNG to verify the dice math, and test the game package's interpretation logic separately with known totals.
+
+```typescript
+import { describe, expect, test } from 'bun:test'
+import { roll } from '@randsum/roller'
+
+// Verify the dice configuration a game package would use
+function seededRandom(seed: number) {
+  let s = seed
+  return () => {
+    s = (s * 1664525 + 1013904223) >>> 0
+    return s / 0x100000000
+  }
+}
+
+describe('5e-style advantage roll (deterministic)', () => {
+  test('2d20 drop lowest produces a value from 1 to 20', () => {
+    const result = roll(
+      { sides: 20, quantity: 2, modifiers: { drop: { lowest: 1 } } },
+      { randomFn: seededRandom(42) }
+    )
+    expect(result.total).toBeGreaterThanOrEqual(1)
+    expect(result.total).toBeLessThanOrEqual(20)
+    expect(result.error).toBeNull()
+  })
+})
+```
+
+## Testing error paths
+
+`roll()` never throws. When given invalid input, it returns a result with a non-null `error` property.
+
+```typescript
+import { describe, expect, test } from 'bun:test'
+import { roll } from '@randsum/roller'
+
+describe('error handling', () => {
+  test('returns an error for invalid notation', () => {
+    const result = roll('not-valid-notation')
+    expect(result.error).not.toBeNull()
+    expect(result.total).toBe(0)
+    expect(result.rolls).toHaveLength(0)
+  })
+
+  test('returns an error for zero sides', () => {
+    const result = roll({ sides: 0, quantity: 1 })
+    expect(result.error).not.toBeNull()
+  })
+
+  test('returns null error for valid input', () => {
+    const result = roll('2d6')
+    expect(result.error).toBeNull()
+  })
+})
+```
+
+Always check `result.error` before using `result.total` in application code — the same pattern applies in tests.

--- a/apps/site/src/content/docs/guides/testing.mdx
+++ b/apps/site/src/content/docs/guides/testing.mdx
@@ -3,8 +3,6 @@ title: Testing
 description: How to write deterministic tests for code that uses RANDSUM
 ---
 
-import { Tabs, TabItem } from '@astrojs/starlight/components'
-
 Rolling dice is inherently random, which makes testing tricky. RANDSUM provides a `randomFn` option on `roll()` so you can inject a deterministic random number generator and make your tests reproducible.
 
 ## Seeded random
@@ -17,8 +15,8 @@ import { roll } from '@randsum/roller'
 function seededRandom(seed: number) {
   let s = seed
   return () => {
-    s = (s * 1664525 + 1013904223) >>> 0
-    return s / 0x100000000
+    s = (s * 1664525 + 1013904223) % 2 ** 32
+    return s / 2 ** 32
   }
 }
 
@@ -38,8 +36,8 @@ import { roll } from '@randsum/roller'
 function seededRandom(seed: number) {
   let s = seed
   return () => {
-    s = (s * 1664525 + 1013904223) >>> 0
-    return s / 0x100000000
+    s = (s * 1664525 + 1013904223) % 2 ** 32
+    return s / 2 ** 32
   }
 }
 
@@ -52,14 +50,11 @@ describe('roll with seeded RNG', () => {
     expect(result1.result).toEqual(result2.result)
   })
 
-  test('produces different totals for different seeds', () => {
-    const result1 = roll('1d20', { randomFn: seededRandom(1) })
-    const result2 = roll('1d20', { randomFn: seededRandom(999) })
-
-    // Not guaranteed to differ, but almost always will for different seeds
-    // Use this pattern only when you know the seed outputs differ
-    expect(result1.error).toBeNull()
-    expect(result2.error).toBeNull()
+  test('returns a valid result for any seed', () => {
+    const result = roll('1d20', { randomFn: seededRandom(42) })
+    expect(result.error).toBeNull()
+    expect(result.total).toBeGreaterThanOrEqual(1)
+    expect(result.total).toBeLessThanOrEqual(20)
   })
 })
 ```
@@ -141,8 +136,8 @@ import { roll } from '@randsum/roller'
 function seededRandom(seed: number) {
   let s = seed
   return () => {
-    s = (s * 1664525 + 1013904223) >>> 0
-    return s / 0x100000000
+    s = (s * 1664525 + 1013904223) % 2 ** 32
+    return s / 2 ** 32
   }
 }
 

--- a/apps/site/src/content/docs/index.mdx
+++ b/apps/site/src/content/docs/index.mdx
@@ -1,10 +1,10 @@
 ---
 title: Welcome to RANDSUM
-description: A modular dice rolling ecosystem for tabletop RPGs
+description: A zero-dependency dice engine with expressive notation
 template: splash
 hero:
   title: RANDSUM
-  tagline: A modular dice rolling ecosystem for tabletop RPGs
+  tagline: A zero-dependency dice engine with expressive notation
   actions:
     - text: Get Started
       link: /getting-started/introduction/
@@ -16,4 +16,4 @@ hero:
       variant: minimal
 ---
 
-Welcome to the RANDSUM documentation. RANDSUM is a TypeScript dice rolling ecosystem built for tabletop RPGs.
+RANDSUM is a zero-dependency dice engine with expressive notation, built for developers who take their dice seriously.

--- a/apps/site/src/content/docs/packages/roller.mdx
+++ b/apps/site/src/content/docs/packages/roller.mdx
@@ -5,9 +5,7 @@ description: The core dice rolling engine that powers the RANDSUM ecosystem
 
 import { Tabs, TabItem } from '@astrojs/starlight/components'
 
-`@randsum/roller` is the core dice rolling engine that powers the entire RANDSUM ecosystem. It provides advanced dice notation support, allowing you to express complex rolling mechanics in a concise, readable format.
-
-Whether you are building a simple dice roller or implementing complex tabletop RPG mechanics, Roller provides the foundation you need with full TypeScript support and zero runtime dependencies.
+`@randsum/roller` is the core dice rolling engine that powers the entire RANDSUM ecosystem. It provides advanced dice notation support for simple and complex rolling mechanics, with full TypeScript types and zero runtime dependencies.
 
 ## Installation
 

--- a/apps/site/src/content/docs/tools/discord-bot.mdx
+++ b/apps/site/src/content/docs/tools/discord-bot.mdx
@@ -3,15 +3,15 @@ title: Discord Bot
 description: Roll dice directly in Discord with the RANDSUM bot
 ---
 
-The **RANDSUM Discord Bot** brings dice rolling directly into your Discord server. Built with [discord.js](https://discord.js.org) and Bun, it provides detailed roll breakdowns and full support for all RANDSUM game packages.
+The **RANDSUM Discord Bot** is a Discord application for rolling dice in chat. Built with [discord.js](https://discord.js.org) and Bun, it provides detailed roll breakdowns and full support for all RANDSUM game packages.
 
 ## Add to your server
 
-The easiest way to get started is to add the bot to your Discord server with one click:
+Add the bot to any Discord server with one click:
 
 [Add RANDSUM to Discord](https://discord.com/oauth2/authorize?client_id=1290434147159904276&permissions=274877906944&scope=bot%20applications.commands)
 
-No setup required -- it works immediately after adding.
+No configuration is required after adding.
 
 ## Commands
 

--- a/apps/site/src/content/docs/tools/skill/index.mdx
+++ b/apps/site/src/content/docs/tools/skill/index.mdx
@@ -5,7 +5,7 @@ description: Use RANDSUM dice rolling in AI assistants and LLM agents
 
 import { Tabs, TabItem } from '@astrojs/starlight/components';
 
-RANDSUM provides a **dice rolling skill** for LLM agents -- a structured prompt and reference that teaches AI assistants how to roll dice using RANDSUM notation for any tabletop RPG system.
+RANDSUM provides a **dice rolling skill** for LLM agents -- a structured prompt and reference that enables AI assistants to roll dice using RANDSUM notation for any tabletop RPG system.
 
 ## What is an LLM skill?
 

--- a/apps/site/src/pages/index.astro
+++ b/apps/site/src/pages/index.astro
@@ -27,7 +27,7 @@ function getAccentColor(pkg: { id: string; color?: string }): string {
 <StarlightPage
   frontmatter={{
     title: 'RANDSUM',
-    description: 'A flexible, type-safe dice rolling ecosystem for tabletop RPGs',
+    description: 'A zero-dependency dice engine with expressive notation, built for developers who take their dice seriously.',
     template: 'splash'
   }}
   hasSidebar={false}
@@ -36,12 +36,15 @@ function getAccentColor(pkg: { id: string; color?: string }): string {
     <!-- Hero -->
     <section class="hero">
       <div class="hero-inner">
-        <Image src={logo} alt="RANDSUM logo" class="hero-logo" width={160} height={160} />
-        <h1 class="hero-title">RANDSUM</h1>
-        <p class="hero-tagline">A flexible, type-safe dice rolling ecosystem</p>
+        <div class="hero-lockup">
+          <div class="hero-logo-wrap">
+            <Image src={logo} alt="RANDSUM logo" class="hero-logo" width={160} height={160} />
+          </div>
+          <h1 class="hero-title">RANDSUM</h1>
+        </div>
+        <p class="hero-tagline">A zero-dependency dice engine with expressive notation</p>
         <p class="hero-subtitle">
-          TypeScript packages for rolling dice and implementing tabletop RPG mechanics.
-          Built for D&D 5e, Blades in the Dark, Daggerheart, Root RPG, Salvage Union, PbtA, and more.
+          Built for developers who take their dice seriously.
         </p>
         <div class="hero-actions">
           <a href="/getting-started/introduction/" class="btn btn-primary">Get Started</a>
@@ -188,11 +191,6 @@ console.<span class="fn">log</span>(result.total)      <span class="cm">// 14</s
                   npm
                 </a>
               </li>
-              <li>
-                <a href="https://discord.gg/randsum" target="_blank" rel="noopener noreferrer">
-                  Discord
-                </a>
-              </li>
             </ul>
           </div>
         </div>
@@ -218,21 +216,21 @@ console.<span class="fn">log</span>(result.total)      <span class="cm">// 14</s
     font-family: var(--sl-font-heading, var(--sl-font));
     font-size: 2rem;
     text-align: center;
-    margin-bottom: 0.5rem;
+    margin-bottom: 0.75rem;
     letter-spacing: -0.02em;
   }
 
   .section-desc {
     text-align: center;
     color: var(--sl-color-gray-2);
-    margin-bottom: 2rem;
+    margin-bottom: 2.5rem;
     font-size: 1.1rem;
   }
 
   /* ===== Hero ===== */
   .hero {
     text-align: center;
-    padding: 2rem 1.5rem 3rem;
+    padding: 5rem 1.5rem 6rem;
     border-bottom: 1px solid var(--sl-color-gray-5);
   }
 
@@ -241,13 +239,49 @@ console.<span class="fn">log</span>(result.total)      <span class="cm">// 14</s
     margin: 0 auto;
   }
 
+  .hero-lockup {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    gap: 1.25rem;
+    margin-bottom: 1.75rem;
+  }
+
+  .hero-logo-wrap {
+    position: relative;
+    display: inline-flex;
+    flex-shrink: 0;
+    animation: levitate 3s ease-in-out infinite;
+  }
+
+  .hero-logo-wrap::after {
+    content: '';
+    position: absolute;
+    bottom: -10px;
+    left: 50%;
+    transform: translateX(-50%);
+    width: 90px;
+    height: 20px;
+    background: radial-gradient(ellipse at center, rgba(59, 130, 246, 0.6) 0%, transparent 70%);
+    border-radius: 50%;
+    filter: blur(6px);
+    animation: glow-pulse 3s ease-in-out infinite;
+  }
+
+  @keyframes levitate {
+    0%, 100% { transform: translateY(0); }
+    50% { transform: translateY(-8px); }
+  }
+
+  @keyframes glow-pulse {
+    0%, 100% { opacity: 1; transform: translateX(-50%) scaleX(1); }
+    50% { opacity: 0.4; transform: translateX(-50%) scaleX(0.7); }
+  }
+
   .hero-logo {
     display: block;
-    margin-left: auto;
-    margin-right: auto;
     width: 120px;
     height: auto;
-    margin-bottom: 1.5rem;
   }
 
   .hero-title {
@@ -255,7 +289,7 @@ console.<span class="fn">log</span>(result.total)      <span class="cm">// 14</s
     font-size: 3.5rem;
     font-weight: 700;
     letter-spacing: -0.03em;
-    margin: 0 0 1rem;
+    margin: 0;
     background: linear-gradient(
       135deg,
       var(--sl-color-accent-high),
@@ -334,7 +368,7 @@ console.<span class="fn">log</span>(result.total)      <span class="cm">// 14</s
 
   /* ===== Code Example ===== */
   .code-example {
-    padding: 3rem 0;
+    padding: 5rem 0;
     border-bottom: 1px solid var(--sl-color-gray-5);
   }
 
@@ -396,7 +430,7 @@ console.<span class="fn">log</span>(result.total)      <span class="cm">// 14</s
 
   /* ===== Package Cards ===== */
   .packages-section {
-    padding: 3rem 0;
+    padding: 5rem 0;
     border-bottom: 1px solid var(--sl-color-gray-5);
   }
 
@@ -560,7 +594,12 @@ console.<span class="fn">log</span>(result.total)      <span class="cm">// 14</s
   /* ===== Responsive ===== */
   @media (max-width: 768px) {
     .hero {
-      padding: 3rem 1rem 2rem;
+      padding: 3.5rem 1rem 4rem;
+    }
+
+    .hero-lockup {
+      flex-direction: column;
+      gap: 0.75rem;
     }
 
     .hero-title {

--- a/apps/site/src/utils/packageData.ts
+++ b/apps/site/src/utils/packageData.ts
@@ -25,7 +25,7 @@ export const corePackages: PackageInfo[] = [
       'Core dice rolling engine with advanced notation support. The foundation of the RANDSUM ecosystem.',
     npmPackage: '@randsum/roller',
     category: 'core',
-    color: 'linear-gradient(90deg, #ff0000, #ff7f00, #ffff00, #00ff00, #0000ff, #4b0082, #9400d3)',
+    color: '#f59e0b', // amber — distinct from all game/tool packages
     features: [
       'Advanced dice notation (4d6L, 2d20H, etc.)',
       'Reroll modifiers',
@@ -366,6 +366,25 @@ bun add @randsum/pbta`,
 ]
 
 export const toolPackages: PackageInfo[] = [
+  {
+    id: 'skill',
+    name: 'skill',
+    displayName: 'LLM Skill',
+    description:
+      'A structured prompt file that teaches AI assistants RANDSUM dice notation and game system mechanics. Compatible with Claude, ChatGPT, and any LLM that supports tool use or custom prompts.',
+    npmPackage: 'skills/dice-rolling/SKILL.md',
+    category: 'tool',
+    color: '#6366f1', // indigo
+    examples: [
+      {
+        title: 'Claude Code Setup',
+        code: `# Download the skill into your project
+curl -o .claude/skills/dice-rolling/SKILL.md \\
+  https://raw.githubusercontent.com/RANDSUM/randsum/main/skills/dice-rolling/SKILL.md`,
+        language: 'bash'
+      }
+    ]
+  },
   {
     id: 'discord-bot',
     name: 'discord-bot',

--- a/packages/blades/README.md
+++ b/packages/blades/README.md
@@ -1,7 +1,7 @@
 <div align="center">
   <img width="150" height="150" src="https://raw.githubusercontent.com/RANDSUM/randsum/refs/heads/main/icon.webp" alt="Randsum Logo">
   <h1>@randsum/blades</h1>
-  <h3>Blades in the Dark compatible dice rolling for Randsum</h3>
+  <h3>Blades in the Dark dice mechanics for <a href="https://github.com/RANDSUM/randsum">@RANDSUM</a></h3>
 
 [![npm version](https://img.shields.io/npm/v/@randsum/blades)](https://www.npmjs.com/package/@randsum/blades)
 [![bundle size](https://img.shields.io/bundlephobia/minzip/@randsum/blades)](https://bundlephobia.com/package/@randsum/blades)
@@ -12,12 +12,7 @@
 
 </div>
 
-A utility for rolling dice in [Forged in the Dark](https://bladesinthedark.com/) systems!
-
-- 🎲 Standard Blades in the Dark position and effect rolls
-- 🎯 Automatic handling of dice pools
-- 🔒 Full TypeScript support
-- 🪶 Lightweight implementation
+Type-safe [Blades in the Dark](https://bladesinthedark.com/) action roll mechanics, built on [@RANDSUM](https://github.com/RANDSUM/randsum).
 
 ## Installation
 

--- a/packages/daggerheart/README.md
+++ b/packages/daggerheart/README.md
@@ -1,7 +1,7 @@
 <div align="center">
   <img width="150" height="150" src="https://raw.githubusercontent.com/RANDSUM/randsum/refs/heads/main/icon.webp" alt="Randsum Logo">
   <h1>@randsum/daggerheart</h1>
-  <h3>Daggerheart dice rolling for Randsum</h3>
+  <h3>Daggerheart Duality Dice mechanics for <a href="https://github.com/RANDSUM/randsum">@RANDSUM</a></h3>
 
 [![npm version](https://img.shields.io/npm/v/@randsum/daggerheart)](https://www.npmjs.com/package/@randsum/daggerheart)
 [![bundle size](https://img.shields.io/bundlephobia/minzip/@randsum/daggerheart)](https://bundlephobia.com/package/@randsum/daggerheart)
@@ -12,7 +12,7 @@
 
 </div>
 
-A type-safe implementation of [Daggerheart](https://daggerheart.com/) Duality Dice mechanics.
+Type-safe [Daggerheart](https://daggerheart.com/) Duality Dice mechanics, built on [@RANDSUM](https://github.com/RANDSUM/randsum).
 
 ## Installation
 

--- a/packages/fifth/README.md
+++ b/packages/fifth/README.md
@@ -1,7 +1,7 @@
 <div align="center">
   <img width="150" height="150" src="https://raw.githubusercontent.com/RANDSUM/randsum/refs/heads/main/icon.webp" alt="Randsum Logo">
   <h1>@randsum/fifth</h1>
-  <h3>5th Edition compatible dice rolling for Randsum</h3>
+  <h3>D&amp;D 5th Edition dice mechanics for <a href="https://github.com/RANDSUM/randsum">@RANDSUM</a></h3>
 
 [![npm version](https://img.shields.io/npm/v/@randsum/fifth)](https://www.npmjs.com/package/@randsum/fifth)
 [![bundle size](https://img.shields.io/bundlephobia/minzip/@randsum/fifth)](https://bundlephobia.com/package/@randsum/fifth)
@@ -12,7 +12,7 @@
 
 </div>
 
-A type-safe implementation of 5th Edition d20 mechanics with advantage/disadvantage.
+Type-safe D&D 5th Edition d20 mechanics with advantage/disadvantage, built on [@RANDSUM](https://github.com/RANDSUM/randsum).
 
 ## Installation
 

--- a/packages/pbta/README.md
+++ b/packages/pbta/README.md
@@ -1,7 +1,7 @@
 <div align="center">
   <img width="150" height="150" src="https://raw.githubusercontent.com/RANDSUM/randsum/refs/heads/main/icon.webp" alt="Randsum Logo">
   <h1>@randsum/pbta</h1>
-  <h3>Powered by the Apocalypse dice rolling for Randsum</h3>
+  <h3>Powered by the Apocalypse dice mechanics for <a href="https://github.com/RANDSUM/randsum">@RANDSUM</a></h3>
 
 [![npm version](https://img.shields.io/npm/v/@randsum/pbta)](https://www.npmjs.com/package/@randsum/pbta)
 [![bundle size](https://img.shields.io/bundlephobia/minzip/@randsum/pbta)](https://bundlephobia.com/package/@randsum/pbta)
@@ -11,15 +11,7 @@
 
 </div>
 
-A type-safe implementation of [Powered by the Apocalypse](https://apocalypse-world.com/) dice rolling mechanics that supports:
-
-- 🎲 Standard 2d6 + stat rolls
-- 🎯 Automatic outcome determination (strong hit, weak hit, miss)
-- ⚡ Advantage/disadvantage mechanics
-- 🔒 Full TypeScript support
-- 🪶 Tree-shakeable implementation
-
-Works with any PbtA game including Dungeon World, Monster of the Week, Apocalypse World, Masks, and more.
+Type-safe [Powered by the Apocalypse](https://apocalypse-world.com/) 2d6+stat mechanics, built on [@RANDSUM](https://github.com/RANDSUM/randsum). Compatible with Dungeon World, Monster of the Week, Apocalypse World, Masks, and other PbtA games.
 
 ## Installation
 

--- a/packages/roller/README.md
+++ b/packages/roller/README.md
@@ -1,7 +1,7 @@
 <div align="center">
   <img width="150" height="150" src="https://raw.githubusercontent.com/RANDSUM/randsum/refs/heads/main/icon.webp" alt="Randsum Logo. A Dotted D6 rolled a 6 with the dots arranged to look like an R.">
   <h1>@randsum/roller</h1>
-  <h3>Advanced Dice Rolling for JavaScript & TypeScript</h3>
+  <h3>A zero-dependency dice engine with expressive notation</h3>
 
 [![npm version](https://img.shields.io/npm/v/@randsum/roller)](https://www.npmjs.com/package/@randsum/roller)
 [![bundle size](https://img.shields.io/bundlephobia/minzip/@randsum/roller)](https://bundlephobia.com/package/@randsum/roller)
@@ -12,7 +12,7 @@
 
 </div>
 
-A flexible, type-safe dice rolling implementation for tabletop RPGs, game development, and probability simulations.
+A zero-dependency dice engine with expressive notation for TypeScript and JavaScript.
 
 ## Installation
 

--- a/packages/root-rpg/README.md
+++ b/packages/root-rpg/README.md
@@ -1,7 +1,7 @@
 <div align="center">
   <img width="150" height="150" src="https://raw.githubusercontent.com/RANDSUM/randsum/refs/heads/main/icon.webp" alt="Randsum Logo">
   <h1>@randsum/root-rpg</h1>
-  <h3>Root RPG compatible dice rolling for Randsum</h3>
+  <h3>Root RPG dice mechanics for <a href="https://github.com/RANDSUM/randsum">@RANDSUM</a></h3>
 
 [![npm version](https://img.shields.io/npm/v/@randsum/root-rpg)](https://www.npmjs.com/package/@randsum/root-rpg)
 [![bundle size](https://img.shields.io/bundlephobia/minzip/@randsum/root-rpg)](https://bundlephobia.com/package/@randsum/root-rpg)
@@ -12,12 +12,7 @@
 
 </div>
 
-A small collection of utilities for [Root RPG](https://magpiegames.com/collections/root)!
-
-- 🎲 Standard Root RPG (2d6+N) rolls
-- 🎯 Automatic handling of modifiers
-- 🔒 Full TypeScript support
-- 🪶 smol (not larger than a wolf)
+Type-safe [Root RPG](https://magpiegames.com/collections/root) 2d6+bonus mechanics, built on [@RANDSUM](https://github.com/RANDSUM/randsum).
 
 ## Installation
 

--- a/packages/salvageunion/README.md
+++ b/packages/salvageunion/README.md
@@ -1,7 +1,7 @@
 <div align="center">
   <img width="150" height="150" src="https://raw.githubusercontent.com/RANDSUM/randsum/refs/heads/main/icon.webp" alt="Randsum Logo">
   <h1>@randsum/salvageunion</h1>
-  <h3>Salvage Union compatible dice rolling for Randsum</h3>
+  <h3>Salvage Union dice mechanics for <a href="https://github.com/RANDSUM/randsum">@RANDSUM</a></h3>
 
 [![npm version](https://img.shields.io/npm/v/@randsum/salvageunion)](https://www.npmjs.com/package/@randsum/salvageunion)
 [![bundle size](https://img.shields.io/bundlephobia/minzip/@randsum/salvageunion)](https://bundlephobia.com/package/@randsum/salvageunion)
@@ -12,13 +12,7 @@
 
 </div>
 
-A type-safe implementation of [Salvage Union](https://www.geargrindergames.com/salvage-union) dice rolling mechanics that supports:
-
-- 🎲 Standard 1d20 rolls against result tables
-- 🎯 Automatic outcome determination
-- 📊 Built-in roll tables
-- 🔒 Full TypeScript support
-- 🪶 Tree-shakeable implementation
+Type-safe [Salvage Union](https://leyline.press/collections/salvage-union) d20 table-based mechanics, built on [@RANDSUM](https://github.com/RANDSUM/randsum).
 
 ## Installation
 


### PR DESCRIPTION
## Summary

- Updates tagline to "zero-dependency dice engine with expressive notation" across README, all docs pages, and the site
- Refactors hero section in `index.astro`: logo+title lockup side-by-side, levitation animation with glow, increased padding, roller color changed from rainbow gradient to amber
- Adds LLM Skill entry to `toolPackages` in `packageData.ts`
- Removes Discord invite link from `astro.config.mjs` and site footer
- Standardizes all game package READMEs to "Type-safe [Game] mechanics, built on @RANDSUM" pattern
- Tightens prose in `roller.mdx`, `discord-bot.mdx`, `skill/index.mdx`, and getting-started docs

## Test plan

- [ ] Site builds without errors (`bun run site:dev`)
- [ ] Hero section renders correctly on desktop and mobile
- [ ] All docs pages load with updated copy
- [ ] No Discord links remain in nav or footer

🤖 Generated with [Claude Code](https://claude.com/claude-code)