### PR TITLE
docs(site): align documentation with notation-into-roller merge

### DIFF
--- a/apps/site/src/content/docs/notation/api-reference.mdx
+++ b/apps/site/src/content/docs/notation/api-reference.mdx
@@ -1,11 +1,11 @@
 ---
 title: Notation API Reference
-description: All exported functions, types, and schemas from @randsum/notation.
+description: All exported functions, types, and schemas from @randsum/roller.
 ---
 
 import CodeExample from '../../../components/live-repl/CodeExample.astro'
 
-All public exports from `@randsum/notation`. Some internal helpers (like `listOfNotations`) are omitted. Three functions (`isDiceNotation`, `notation`, `validateNotation`), `NotationParseError`, and all types are also re-exported from `@randsum/roller`. All other functions require importing from `@randsum/notation` directly.
+All functions on this page are exported from `@randsum/roller`. Some internal helpers (like `listOfNotations`) are omitted. The `tokenize` function is also available from `@randsum/roller/tokenize` for lightweight use.
 
 ## Parse functions
 
@@ -13,7 +13,7 @@ All public exports from `@randsum/notation`. Some internal helpers (like `listOf
 
 Type guard that returns `true` if the string is valid dice notation.
 
-<CodeExample code={`import { isDiceNotation } from '@randsum/notation'
+<CodeExample code={`import { isDiceNotation } from '@randsum/roller'
 
 isDiceNotation('4d6L')   // true — value is typed as DiceNotation
 isDiceNotation('hello')  // false`} />
@@ -36,7 +36,7 @@ function notation(value: string): DiceNotation
 
 Parse a notation string into structured options. Accepts any string (validate first with `isDiceNotation` for safety). Returns an array (one entry per roll group).
 
-<CodeExample code={`import { notationToOptions, isDiceNotation } from '@randsum/notation'
+<CodeExample code={`import { notationToOptions, isDiceNotation } from '@randsum/roller'
 
 if (isDiceNotation('4d6L+2')) {
   const [options] = notationToOptions('4d6L+2')
@@ -53,7 +53,7 @@ function notationToOptions(notation: string): ParsedNotationOptions[]
 
 Validate with detailed result. Returns `ValidValidationResult` or `InvalidValidationResult`.
 
-<CodeExample code={`import { validateNotation } from '@randsum/notation'
+<CodeExample code={`import { validateNotation } from '@randsum/roller'
 
 const result = validateNotation('4d6L')
 if (result.valid) {
@@ -73,7 +73,7 @@ function validateNotation(notation: string): ValidationResult
 
 Suggest a corrected version of invalid notation. Returns `undefined` if no fix is available.
 
-<CodeExample code={`import { suggestNotationFix } from '@randsum/notation'
+<CodeExample code={`import { suggestNotationFix } from '@randsum/roller'
 
 suggestNotationFix('d6')    // '1d6'
 suggestNotationFix('46')    // '4d6'
@@ -99,7 +99,7 @@ const coreNotationPattern: RegExp
 
 Convert a `RollOptions` object to a notation string.
 
-<CodeExample code={`import { optionsToNotation } from '@randsum/notation'
+<CodeExample code={`import { optionsToNotation } from '@randsum/roller'
 
 optionsToNotation({ sides: 6, quantity: 4, modifiers: { drop: { lowest: 1 } } })
 // '4d6L'`} />

--- a/apps/site/src/content/docs/notation/getting-started.mdx
+++ b/apps/site/src/content/docs/notation/getting-started.mdx
@@ -1,36 +1,18 @@
 ---
 title: Getting Started with Notation
-description: Install @randsum/notation to validate and parse dice notation without the roll engine.
+description: Use notation validation and parsing from @randsum/roller.
 ---
 
 import { Tabs, TabItem } from '@astrojs/starlight/components'
 import CodeExample from '../../../components/live-repl/CodeExample.astro'
 
-Install `@randsum/notation` to validate and parse dice notation strings without the roll engine.
-
-## Install
-
-<Tabs>
-  <TabItem label="bun">
-    <CodeExample lang="bash" code={`bun add @randsum/notation`} />
-  </TabItem>
-  <TabItem label="npm">
-    <CodeExample lang="bash" code={`npm install @randsum/notation`} />
-  </TabItem>
-  <TabItem label="yarn">
-    <CodeExample lang="bash" code={`yarn add @randsum/notation`} />
-  </TabItem>
-</Tabs>
-
-:::tip[Need to roll dice too?]
-If you also need `roll()`, install `@randsum/roller` instead. It re-exports `isDiceNotation`, `notation`, and `validateNotation` for convenience. Functions like `notationToOptions`, `suggestNotationFix`, and `tokenize` require a separate `@randsum/notation` install.
-:::
+Notation validation and parsing are built into `@randsum/roller` — no separate package required. Install roller to get `isDiceNotation`, `validateNotation`, `notationToOptions`, `optionsToNotation`, and the full notation toolkit.
 
 ## Quick notation examples
 
 Standard dice, special dice types, and modifiers all work with every notation function:
 
-<CodeExample code={`import { isDiceNotation } from '@randsum/notation'
+<CodeExample code={`import { isDiceNotation } from '@randsum/roller'
 
 isDiceNotation('4d6L')                // true — standard notation
 isDiceNotation('z6')                  // true — zero-bias die (faces 0-5)
@@ -44,7 +26,7 @@ isDiceNotation('6d6sd')               // true — sort descending`} />
 
 Use `isDiceNotation()` as a type guard to check user input before processing it:
 
-<CodeExample code={`import { isDiceNotation } from '@randsum/notation'
+<CodeExample code={`import { isDiceNotation } from '@randsum/roller'
 
 isDiceNotation('4d6L')       // true
 isDiceNotation('not-valid')  // false
@@ -57,7 +39,7 @@ if (isDiceNotation(userInput)) {
 
 `validateNotation()` returns a result object with either the parsed structure or error details:
 
-<CodeExample code={`import { validateNotation } from '@randsum/notation'
+<CodeExample code={`import { validateNotation } from '@randsum/roller'
 
 const result = validateNotation('4d6L')
 
@@ -72,7 +54,7 @@ if (result.valid) {
 
 Convert a notation string into structured `ParsedNotationOptions`. Returns an array (one entry per roll group):
 
-<CodeExample code={`import { isDiceNotation, notationToOptions } from '@randsum/notation'
+<CodeExample code={`import { isDiceNotation, notationToOptions } from '@randsum/roller'
 
 const notation = '2d6+3'
 
@@ -85,7 +67,7 @@ if (isDiceNotation(notation)) {
 
 ## Convert options back to notation
 
-<CodeExample code={`import { optionsToNotation } from '@randsum/notation'
+<CodeExample code={`import { optionsToNotation } from '@randsum/roller'
 
 const notation = optionsToNotation({
   sides: 6,
@@ -98,4 +80,4 @@ console.log(notation) // '4d6L'`} />
 
 - [Randsum Dice Notation Spec](/notation/randsum-dice-notation/) -- full syntax reference for all notation features
 - [Validation & Parsing](/notation/validation-and-parsing/) -- detailed guide to validation, suggestions, and parsing
-- [API Reference](/notation/api-reference/) -- complete list of exports from `@randsum/notation`
+- [API Reference](/notation/api-reference/) -- complete list of exports from `@randsum/roller`

--- a/apps/site/src/content/docs/notation/introduction.mdx
+++ b/apps/site/src/content/docs/notation/introduction.mdx
@@ -1,6 +1,6 @@
 ---
-title: "@randsum/notation"
-description: Parse, validate, and transform dice notation strings without a roll engine. Zero-dependency TypeScript package for notation utilities, type guards, and structured options.
+title: "Dice Notation"
+description: Parse, validate, and transform dice notation strings with @randsum/roller. Zero-dependency TypeScript utilities for notation validation, type guards, and structured options.
 head:
   - tag: script
     attrs:
@@ -9,14 +9,14 @@ head:
       {
         "@context": "https://schema.org",
         "@type": "SoftwareApplication",
-        "name": "@randsum/notation",
+        "name": "Dice Notation",
         "applicationCategory": "DeveloperApplication",
         "programmingLanguage": "TypeScript",
-        "description": "Zero-dependency dice notation parser for the RANDSUM ecosystem. Parses dice notation strings into structured options.",
+        "description": "Zero-dependency dice notation parser built into @randsum/roller. Parses dice notation strings into structured options.",
         "offers": { "@type": "Offer", "price": "0" },
-        "downloadUrl": "https://www.npmjs.com/package/@randsum/notation",
-        "codeRepository": "https://github.com/RANDSUM/randsum/tree/main/packages/notation",
-        "keywords": "dice notation parser, TypeScript, dice, tabletop RPG, npm package"
+        "downloadUrl": "https://www.npmjs.com/package/@randsum/roller",
+        "codeRepository": "https://github.com/RANDSUM/randsum/tree/main/packages/roller",
+        "keywords": "dice notation parser, TypeScript, dice, tabletop RPG, randsum roller"
       }
   - tag: script
     attrs:
@@ -34,24 +34,13 @@ head:
 
 import CodeExample from '../../../components/live-repl/CodeExample.astro'
 
-Parse, validate, and transform dice notation strings without a roll engine. `@randsum/notation` is the type foundation of the RANDSUM ecosystem — zero runtime dependencies. Supports 19 modifier schemas, special dice types (geometric, draw), annotations, and the repeat operator.
-
-## When to use notation vs roller
-
-Use `@randsum/notation` when you need notation utilities but not `roll()`:
-
-- Validating user-provided dice strings in a form or chat command
-- Building a notation editor or input component
-- Converting between notation strings and structured options
-- Tokenizing notation for syntax highlighting
-
-If you also need to roll dice, use [`@randsum/roller`](/roller/introduction/) instead — it re-exports `validateNotation`, `isDiceNotation`, and `notation` for convenience. Functions like `notationToOptions`, `suggestNotationFix`, and `tokenize` require `@randsum/notation` directly.
+Parse, validate, and transform dice notation strings — all built into `@randsum/roller`. Notation is a core capability of the roller, not a separate package. It supports 19 modifier schemas, special dice types (geometric, draw), annotations, and the repeat operator, with zero runtime dependencies.
 
 ## What it does
 
 **Validation** — check if a string is valid dice notation, with type narrowing or structured error details.
 
-<CodeExample code={`import { isDiceNotation, validateNotation } from '@randsum/notation'
+<CodeExample code={`import { isDiceNotation, validateNotation } from '@randsum/roller'
 
 // Type guard — narrows to DiceNotation
 if (isDiceNotation(userInput)) {
@@ -66,14 +55,14 @@ if (!result.valid) {
 
 **Parsing** — convert notation strings into structured `ParsedNotationOptions` arrays.
 
-<CodeExample code={`import { notationToOptions } from '@randsum/notation'
+<CodeExample code={`import { notationToOptions } from '@randsum/roller'
 
 const options = notationToOptions('4d6L')
 // [{ sides: 6, quantity: 4, modifiers: { drop: { lowest: 1 } } }]`} />
 
 **Transformation** — convert structured options back to notation strings or human-readable descriptions.
 
-<CodeExample code={`import { optionsToNotation, optionsToDescription } from '@randsum/notation'
+<CodeExample code={`import { optionsToNotation, optionsToDescription } from '@randsum/roller'
 
 const options = {
   sides: 6,
@@ -86,13 +75,13 @@ optionsToDescription(options)  // ['Roll 4 6-sided dice', 'Drop lowest']`} />
 
 **Suggestion** — offer corrected notation for invalid input.
 
-<CodeExample code={`import { suggestNotationFix } from '@randsum/notation'
+<CodeExample code={`import { suggestNotationFix } from '@randsum/roller'
 
 suggestNotationFix('d20')  // '1d20' — adds missing quantity`} />
 
 **Tokenization** — break notation into typed tokens for syntax highlighting or UI display.
 
-<CodeExample code={`import { tokenize } from '@randsum/notation'
+<CodeExample code={`import { tokenize } from '@randsum/roller'
 
 const tokens = tokenize('4d6L+5')
 // Each token has: text, type, start, end, description`} />
@@ -106,5 +95,5 @@ const tokens = tokenize('4d6L+5')
 
 ## Links
 
-- [npm package](https://www.npmjs.com/package/@randsum/notation)
-- [Source code](https://github.com/RANDSUM/randsum/tree/main/packages/notation)
+- [npm package](https://www.npmjs.com/package/@randsum/roller)
+- [Source code](https://github.com/RANDSUM/randsum/tree/main/packages/roller)

--- a/apps/site/src/content/docs/notation/validation-and-parsing.mdx
+++ b/apps/site/src/content/docs/notation/validation-and-parsing.mdx
@@ -1,6 +1,6 @@
 ---
 title: Validation & Parsing
-description: Validate user input, parse notation into structured options, and convert between formats with @randsum/notation.
+description: Validate user input, parse notation into structured options, and convert between formats with @randsum/roller.
 head:
   - tag: script
     attrs:
@@ -19,7 +19,7 @@ head:
 
 import CodeExample from '../../../components/live-repl/CodeExample.astro'
 
-Validate user input, parse notation into structured options, and convert between formats. All functions on this page are exported from `@randsum/notation`. Three validation functions — `isDiceNotation`, `notation`, and `validateNotation` — are also re-exported from `@randsum/roller` for convenience. Everything else requires `@randsum/notation` directly.
+Validate user input, parse notation into structured options, and convert between formats. All functions on this page are exported from `@randsum/roller`.
 
 ## Validation
 
@@ -27,7 +27,7 @@ Validate user input, parse notation into structured options, and convert between
 
 Type guard that returns `true` if the string is valid dice notation. Use this for quick checks before passing input to `roll()`.
 
-<CodeExample code={`import { isDiceNotation } from '@randsum/notation'
+<CodeExample code={`import { isDiceNotation } from '@randsum/roller'
 
 isDiceNotation('4d6L')   // true — typed as DiceNotation
 isDiceNotation('2d6+3')  // true
@@ -38,7 +38,7 @@ isDiceNotation('4dX')    // false — non-numeric sides`} />
 
 Returns a detailed result object with either the parsed structure or an error:
 
-<CodeExample code={`import { validateNotation } from '@randsum/notation'
+<CodeExample code={`import { validateNotation } from '@randsum/roller'
 
 const valid = validateNotation('4d6L')
 // { valid: true, notation: ['4d6L'], options: [{ sides: 6, quantity: 4, ... }] }
@@ -52,7 +52,7 @@ Use this instead of `isDiceNotation()` when you need to show error messages to t
 
 Suggests a corrected version of invalid notation. Returns `undefined` if no suggestion is available.
 
-<CodeExample code={`import { suggestNotationFix } from '@randsum/notation'
+<CodeExample code={`import { suggestNotationFix } from '@randsum/roller'
 
 suggestNotationFix('d6')      // '1d6'  — missing quantity
 suggestNotationFix('4 d 6')   // '4d6'  — extra whitespace
@@ -61,7 +61,7 @@ suggestNotationFix('xyz')     // undefined — no suggestion`} />
 
 Combine with `validateNotation()` for a complete user-facing validation flow:
 
-<CodeExample code={`import { validateNotation, suggestNotationFix } from '@randsum/notation'
+<CodeExample code={`import { validateNotation, suggestNotationFix } from '@randsum/roller'
 
 function validateUserInput(input: string) {
   const result = validateNotation(input)
@@ -79,7 +79,7 @@ function validateUserInput(input: string) {
 
 Assert that a string is valid notation or throw `NotationParseError`. Returns the input narrowed to the `DiceNotation` type. The thrown error includes a `suggestion` property when a fix can be inferred.
 
-<CodeExample code={`import { notation } from '@randsum/notation'
+<CodeExample code={`import { notation } from '@randsum/roller'
 
 const n = notation('4d6L')  // returns '4d6L' as DiceNotation
 notation('bad')             // throws NotationParseError`} />
@@ -90,7 +90,7 @@ notation('bad')             // throws NotationParseError`} />
 
 Parse a notation string into an array of `ParsedNotationOptions` objects — one per dice group in the expression:
 
-<CodeExample code={`import { isDiceNotation, notationToOptions } from '@randsum/notation'
+<CodeExample code={`import { isDiceNotation, notationToOptions } from '@randsum/roller'
 
 if (isDiceNotation('4d6R{1}L+2')) {
   const options = notationToOptions('4d6R{1}L+2')
@@ -113,7 +113,7 @@ if (isDiceNotation('4d6R{1}L+2')) {
 
 Convert a `RollOptions` object back into a notation string:
 
-<CodeExample code={`import { optionsToNotation } from '@randsum/notation'
+<CodeExample code={`import { optionsToNotation } from '@randsum/roller'
 
 optionsToNotation({ sides: 6, quantity: 4, modifiers: { drop: { lowest: 1 } } })
 // '4d6L'`} />
@@ -122,7 +122,7 @@ optionsToNotation({ sides: 6, quantity: 4, modifiers: { drop: { lowest: 1 } } })
 
 Generate a human-readable description of the roll. Returns an array of description strings:
 
-<CodeExample code={`import { optionsToDescription } from '@randsum/notation'
+<CodeExample code={`import { optionsToDescription } from '@randsum/roller'
 
 optionsToDescription({ sides: 6, quantity: 4, modifiers: { drop: { lowest: 1 } } })
 // ['Roll 4 6-sided dice', 'Drop lowest']`} />
@@ -131,7 +131,7 @@ optionsToDescription({ sides: 6, quantity: 4, modifiers: { drop: { lowest: 1 } }
 
 Convert just the modifier portion. `modifiersToNotation` returns a single string; `modifiersToDescription` returns an array of description strings:
 
-<CodeExample code={`import { modifiersToNotation, modifiersToDescription } from '@randsum/notation'
+<CodeExample code={`import { modifiersToNotation, modifiersToDescription } from '@randsum/roller'
 
 modifiersToNotation({ drop: { lowest: 1 }, plus: 3 })
 // 'L+3'
@@ -145,7 +145,7 @@ modifiersToDescription({ drop: { lowest: 1 }, plus: 3 })
 
 Parse a notation string into typed tokens for syntax highlighting or UI display. Each token includes its position, type, and a human-readable description.
 
-<CodeExample code={`import { tokenize } from '@randsum/notation'
+<CodeExample code={`import { tokenize } from '@randsum/roller'
 
 const tokens = tokenize('4d6L+2')
 // [

--- a/apps/site/src/content/docs/roller/api-reference.mdx
+++ b/apps/site/src/content/docs/roller/api-reference.mdx
@@ -5,7 +5,7 @@ description: All exported functions, types, and error classes from @randsum/roll
 
 import CodeExample from '../../../components/live-repl/CodeExample.astro'
 
-Everything exported from `@randsum/roller`. Items marked **re-export** originate from `@randsum/notation` and are re-exported for convenience -- see the [Notation API Reference](/notation/api-reference/) for full details.
+Everything exported from `@randsum/roller`. All functions and types below are exported directly from roller — notation parsing is built in with no separate package required.
 
 ## Functions
 
@@ -34,7 +34,7 @@ function roll<T = string>(
 ): RollerRollResult<T>
 ```
 
-### `validateNotation(notation)` (re-export)
+### `validateNotation(notation)`
 
 Validate a dice notation string and return a detailed result with parsed structure or error.
 
@@ -54,7 +54,7 @@ if (result.valid) {
 function validateNotation(notation: string): ValidationResult
 ```
 
-### `isDiceNotation(value)` (re-export)
+### `isDiceNotation(value)`
 
 Type guard that checks whether a string is valid dice notation.
 
@@ -71,7 +71,7 @@ if (isDiceNotation(userInput)) {
 function isDiceNotation(value: string): value is DiceNotation
 ```
 
-### `notation(value)` (re-export)
+### `notation(value)`
 
 Assert a string is valid dice notation or throw `NotationParseError`.
 
@@ -94,7 +94,7 @@ Validators for numeric input. Used by the roller engine and game packages. Each 
 
 ## Error classes
 
-`RandsumError` extends `Error` and adds a `code` property. `ValidationError`, `ModifierError`, and `RollError` all extend `RandsumError`. `NotationParseError` extends `Error` directly (it is re-exported from `@randsum/notation`).
+`RandsumError` extends `Error` and adds a `code` property. `ValidationError`, `ModifierError`, and `RollError` all extend `RandsumError`. `NotationParseError` extends `Error` directly and is part of `@randsum/roller`.
 
 | Class | Extends | Code | Thrown when |
 |---|---|---|---|
@@ -102,7 +102,7 @@ Validators for numeric input. Used by the roller engine and game packages. Each 
 | `ValidationError` | `RandsumError` | `VALIDATION_ERROR` | Invalid input (zero sides, negative quantity, etc.) |
 | `ModifierError` | `RandsumError` | `MODIFIER_ERROR` | Modifier produces invalid state (e.g. dropping all dice) |
 | `RollError` | `RandsumError` | `ROLL_ERROR` | General roll execution failure |
-| `NotationParseError` (re-export) | `Error` | `INVALID_NOTATION` | Invalid dice notation string |
+| `NotationParseError` | `Error` | `INVALID_NOTATION` | Invalid dice notation string |
 
 ### `ERROR_CODES`
 
@@ -161,14 +161,14 @@ Generic base type.
 | Type | Description |
 |---|---|
 | `RollArgument<T>` | `RollOptions<T> \| DiceNotation \| number` |
-| `RollOptions<T>` | Options object with `sides`, `quantity`, `modifiers` (re-export) |
+| `RollOptions<T>` | Options object with `sides`, `quantity`, `modifiers` |
 | `RollConfig` | `{ randomFn?: RandomFn }` -- pass as last argument to `roll()` |
 | `RandomFn` | `() => number` -- must return `[0, 1)` |
-| `DiceNotation` | Branded string type for valid notation (re-export) |
+| `DiceNotation` | Branded string type for valid notation |
 
-## Modifier types (re-exports)
+## Modifier types
 
-All modifier option types are re-exported from `@randsum/notation`.
+All modifier option types are exported from `@randsum/roller`.
 
 | Type | Description |
 |---|---|
@@ -192,7 +192,7 @@ All modifier option types are re-exported from `@randsum/notation`.
 | `ModifierLog` | `{ modifier, options, added, removed }` -- log entry for one modifier |
 | `NumericRollBonus` | `{ rolls: number[], logs: ModifierLog[] }` -- intermediate modifier state |
 
-## Validation result types (re-exports)
+## Validation result types
 
 | Type | Description |
 |---|---|

--- a/apps/site/src/content/docs/roller/error-handling.mdx
+++ b/apps/site/src/content/docs/roller/error-handling.mdx
@@ -21,7 +21,7 @@ Valid-but-unusual inputs (like `roll(1)` for a single-sided die) are not errors.
 
 ## Error hierarchy
 
-`roll()` can throw two families of errors. `RandsumError` and its subclasses come from `@randsum/roller`. `NotationParseError` extends `Error` directly and comes from `@randsum/notation` (re-exported by roller).
+`roll()` can throw two families of errors. `RandsumError` and its subclasses come from `@randsum/roller`. `NotationParseError` extends `Error` directly and is part of `@randsum/roller`.
 
 | Class | Extends | Code | When |
 |---|---|---|---|
@@ -99,7 +99,7 @@ console.log(rollUserInput('not-dice'))`} />
 | `'d6'` | No | Missing quantity |
 
 <Aside type="tip">
-  `suggestNotationFix()` from `@randsum/notation` can correct common mistakes like missing quantity (`'d6'` → `'1d6'`). When `roll()` throws a `NotationParseError`, the `suggestion` property already contains the result of this function. See [Validation & Parsing](/notation/validation-and-parsing/) for details.
+  `suggestNotationFix()` from `@randsum/roller` can correct common mistakes like missing quantity (`'d6'` → `'1d6'`). When `roll()` throws a `NotationParseError`, the `suggestion` property already contains the result of this function. See [Validation & Parsing](/notation/validation-and-parsing/) for details.
 </Aside>
 
 ## Try/catch

--- a/apps/site/src/content/docs/roller/introduction.mdx
+++ b/apps/site/src/content/docs/roller/introduction.mdx
@@ -12,7 +12,7 @@ head:
         "name": "@randsum/roller",
         "applicationCategory": "DeveloperApplication",
         "programmingLanguage": "TypeScript",
-        "description": "TypeScript dice engine. Parses and evaluates dice notation with full input validation. Ships as ESM and CommonJS.",
+        "description": "TypeScript dice engine. Parses and evaluates dice notation with full input validation. Ships as ESM.",
         "offers": { "@type": "Offer", "price": "0" },
         "downloadUrl": "https://www.npmjs.com/package/@randsum/roller",
         "codeRepository": "https://github.com/RANDSUM/randsum/tree/main/packages/roller",
@@ -35,7 +35,7 @@ head:
 import CodeExample from '../../../components/live-repl/CodeExample.astro'
 import { RollerPlayground } from '@randsum/component-library'
 
-Roll dice with a single function call — numbers, notation strings, or options objects. `@randsum/roller` is the core engine that powers the entire RANDSUM ecosystem: full TypeScript types, strict input validation, and a single dependency (`@randsum/notation`).
+Roll dice with a single function call — numbers, notation strings, or options objects. `@randsum/roller` is the core engine that powers the entire RANDSUM ecosystem: full TypeScript types, strict input validation, and zero dependencies — notation parsing is built in.
 
 ## Features
 

--- a/apps/site/src/content/docs/tools/component-library.mdx
+++ b/apps/site/src/content/docs/tools/component-library.mdx
@@ -20,7 +20,7 @@ import { RollerPlayground, ModifierReference } from '@randsum/component-library'
   </TabItem>
 </Tabs>
 
-Requires `react`, `react-dom`, `@randsum/roller`, and `@randsum/notation` as peer dependencies.
+Requires `react`, `react-dom`, and `@randsum/roller` as peer dependencies.
 
 ## RollerPlayground
 

--- a/apps/site/src/content/docs/welcome/ecosystem-overview.mdx
+++ b/apps/site/src/content/docs/welcome/ecosystem-overview.mdx
@@ -5,47 +5,35 @@ description: How RANDSUM packages relate to each other and where to start.
 
 import { Card, CardGrid } from '@astrojs/starlight/components'
 
-RANDSUM is a monorepo with three layers: a notation parser, a dice engine, and game-specific packages. Every package is TypeScript-first, ships ESM + CJS with full type declarations, and is published to npm under `@randsum`.
+RANDSUM is a monorepo with three layers: a dice engine (with built-in notation parsing), and game-specific packages. Every package is TypeScript-first, ships ESM with full type declarations, and is published to npm under `@randsum`.
 
 ## Dependency diagram
 
 ```
-@randsum/notation              (zero dependencies)
+@randsum/roller              (zero dependencies — includes notation)
   |
-  +-- @randsum/roller          (core dice engine)
-  |     |
-  |     +-- @randsum/games     (TTRPG game packages)
-  |     |     +-- /blades        (Blades in the Dark)
-  |     |     +-- /daggerheart   (Daggerheart)
-  |     |     +-- /fifth         (D&D 5e)
-  |     |     +-- /pbta          (Powered by the Apocalypse)
-  |     |     +-- /root-rpg      (Root RPG)
-  |     |     +-- /salvageunion  (Salvage Union)
-  |     |
-  |     +-- @randsum/display-utils       (UI helpers, peers on roller)
-  |           |
-  |           +-- @randsum/component-library (React components, also peers on notation + react)
+  +-- @randsum/games         (TTRPG game packages)
+  |     +-- /blades            (Blades in the Dark)
+  |     +-- /daggerheart       (Daggerheart)
+  |     +-- /fifth             (D&D 5e)
+  |     +-- /pbta              (Powered by the Apocalypse)
+  |     +-- /root-rpg          (Root RPG)
+  |     +-- /salvageunion      (Salvage Union)
+  |
+  +-- @randsum/display-utils       (UI helpers, peers on roller)
+        |
+        +-- @randsum/component-library (React components, also peers on roller + react)
 ```
 
-Every package depends only on packages above it in the tree. Game packages never depend on each other. The component library depends on display-utils (dev), and peers on notation, roller, and react.
+Every package depends only on packages above it in the tree. Game packages never depend on each other.
 
 ## Packages by layer
-
-### Foundation: Notation
-
-<CardGrid>
-  <Card title="@randsum/notation" icon="pencil">
-    Zero-dependency dice notation parser, validator, and type system. Parses strings like `"4d6L"` into structured options, validates user input, and provides the shared types that the rest of the ecosystem builds on.
-
-    [Learn more](/notation/introduction/)
-  </Card>
-</CardGrid>
 
 ### Core: Roller
 
 <CardGrid>
   <Card title="@randsum/roller" icon="rocket">
-    The dice rolling engine. Accepts numbers, notation strings, or options objects and returns typed roll results with full modifier support. Re-exports three notation functions (`isDiceNotation`, `notation`, `validateNotation`) for convenience -- most projects only need this package.
+    The zero-dependency dice rolling engine with built-in notation parsing and validation. Accepts numbers, notation strings, or options objects and returns typed roll results with full modifier support. Includes `isDiceNotation`, `notation`, `validateNotation`, `notationToOptions`, `optionsToNotation`, `tokenize`, and more — most projects only need this package.
 
     [Learn more](/roller/introduction/)
   </Card>
@@ -72,7 +60,7 @@ Currently supported games: **Blades in the Dark**, **D&D 5e**, **Daggerheart**, 
     [Learn more](/tools/display-utils/)
   </Card>
   <Card title="@randsum/component-library" icon="puzzle">
-    React component library providing interactive dice rolling UI elements. Depends on roller, notation, and display-utils.
+    React component library providing interactive dice rolling UI elements. Depends on roller and display-utils.
 
     [Learn more](/tools/component-library/)
   </Card>
@@ -90,16 +78,16 @@ Pick the package that matches your use case:
 | Use case | Install | Start here |
 |---|---|---|
 | **Roll dice in any JS/TS project** | `bun add @randsum/roller` | [Roller Getting Started](/roller/getting-started/) |
-| **Parse or validate notation strings without rolling** | `bun add @randsum/notation` | [Notation Getting Started](/notation/getting-started/) |
+| **Parse or validate notation strings** | `bun add @randsum/roller` | [Roller Getting Started](/roller/getting-started/) |
 | **Build a TTRPG app with game-specific mechanics** | `bun add @randsum/games` | [Games Getting Started](/games/getting-started/) |
 | **Add dice UI components to a React app** | `bun add @randsum/component-library` | [Component Library](/tools/component-library/) |
 
-Most developers should start with `@randsum/roller`. It re-exports the three most common notation functions (`isDiceNotation`, `notation`, `validateNotation`) plus all types, so most projects only need one install. Add `@randsum/notation` if you need `notationToOptions`, `optionsToNotation`, `tokenize`, or other transform functions.
+Most developers should start with `@randsum/roller`. It includes the full notation parser and validator along with all rolling functionality and types, so most projects only need one install. Notation functions like `isDiceNotation`, `validateNotation`, `notationToOptions`, `optionsToNotation`, `tokenize`, and others are all exported directly from `@randsum/roller`.
 
 ## Design principles
 
-- **Zero core dependencies** -- `@randsum/notation` has no runtime dependencies; `@randsum/roller` depends only on notation
+- **Zero core dependencies** -- `@randsum/roller` has no runtime dependencies and includes the full notation parser and validator
 - **Throws on invalid input** -- `roll()` throws typed errors on bad input (`ValidationError`, `ModifierError`, or `NotationParseError`); validate user-provided strings with `isDiceNotation()` or `validateNotation()` before rolling
 - **Game packages are code-generated** -- every game is defined as a `.randsum.json` spec and transformed into TypeScript by an internal codegen pipeline
 - **Strict TypeScript** -- `isolatedDeclarations`, `exactOptionalPropertyTypes`, `noUncheckedIndexedAccess`, no `any`
-- **Bundle size enforced** -- roller under 10KB, notation under 13KB, game packages under 8KB each
+- **Bundle size enforced** -- roller 20KB (includes notation), display-utils 20KB, game packages under 8KB each

--- a/apps/site/src/content/docs/welcome/introduction.mdx
+++ b/apps/site/src/content/docs/welcome/introduction.mdx
@@ -22,8 +22,7 @@ import { RollerPlayground } from '@randsum/component-library'
 
 RANDSUM is a TypeScript-first dice engine for tabletop RPGs and game development.
 
-- **`@randsum/roller`** — roll dice with a single function call, apply modifiers, get typed results
-- **`@randsum/notation`** — parse and validate [Randsum Dice Notation](/notation/randsum-dice-notation/) strings independently
+- **`@randsum/roller`** — roll dice with a single function call, apply modifiers, parse and validate [Randsum Dice Notation](/notation/randsum-dice-notation/) strings, get typed results
 - **`@randsum/games`** — game-specific roll functions for Salvage Union, D&D 5e, PbtA, and more
 
 ## Your first roll
@@ -86,25 +85,11 @@ import { roll } from '@randsum/games/salvageunion' // Salvage Union
 import { roll } from '@randsum/games/fifth'        // D&D 5e
 import { roll } from '@randsum/games/pbta'         // Powered by the Apocalypse`} />
   </TabItem>
-  <TabItem label="Notation">
-    Parse and validate dice notation strings without the roll engine. Install this only if you don't need `roll()` — `@randsum/roller` already re-exports `validateNotation`, `isDiceNotation`, and `notation`.
-    <Tabs>
-      <TabItem label="bun">
-        <CodeExample lang="bash" code={`bun add @randsum/notation`} />
-      </TabItem>
-      <TabItem label="npm">
-        <CodeExample lang="bash" code={`npm install @randsum/notation`} />
-      </TabItem>
-      <TabItem label="yarn">
-        <CodeExample lang="bash" code={`yarn add @randsum/notation`} />
-      </TabItem>
-    </Tabs>
-  </TabItem>
 </Tabs>
 
 ## Runtime support
 
-All packages ship as ESM and CJS with full type declarations. No Node.js built-ins required.
+All packages ship as ESM with full type declarations. No Node.js built-ins required.
 
 | Runtime | Supported |
 |---|---|
@@ -115,13 +100,13 @@ All packages ship as ESM and CJS with full type declarations. No Node.js built-i
 | Edge functions (Cloudflare, Vercel) | Yes |
 
 <Aside type="tip" title="When does roll() throw?">
-`roll()` throws on invalid input — `NotationParseError` for bad notation strings, `ValidationError` or `ModifierError` (both extending `RandsumError`) for impossible option values or unsatisfiable modifier conditions. Hardcoded notation in your source code will never throw. For user-provided strings, validate first with `validateNotation()` or `isDiceNotation()` (available from both `@randsum/roller` and `@randsum/notation`). See [Error Handling](/roller/error-handling/) for the full pattern.
+`roll()` throws on invalid input — `NotationParseError` for bad notation strings, `ValidationError` or `ModifierError` (both extending `RandsumError`) for impossible option values or unsatisfiable modifier conditions. Hardcoded notation in your source code will never throw. For user-provided strings, validate first with `validateNotation()` or `isDiceNotation()` (available from `@randsum/roller`). See [Error Handling](/roller/error-handling/) for the full pattern.
 </Aside>
 
 ## Where to go next
 
 - **[Roller — Getting Started](/roller/getting-started/)** — learn the `roll()` function, modifiers, and result types
-- **[Notation — Getting Started](/notation/getting-started/)** — parse and validate dice notation strings
+- **[Dice Notation](/notation/getting-started/)** — parse and validate dice notation strings
 - **[Games — Getting Started](/games/getting-started/)** — roll with game-specific mechanics for Salvage Union, D&D 5e, PbtA, and more
 - **[Ecosystem Overview](/welcome/ecosystem-overview/)** — how the packages fit together
 

--- a/apps/site/src/pages/index.astro
+++ b/apps/site/src/pages/index.astro
@@ -6,7 +6,6 @@ import { SpinningLogo, ClickSubtitle, GetStartedButton, GithubButton, HeroRoller
 
 const gameColorMap: Record<string, string> = {
   roller: 'var(--core-roller)',
-  notation: 'var(--core-notation)',
   fifth: 'var(--game-fifth)',
   blades: 'var(--game-blades)',
   daggerheart: 'var(--game-daggerheart)',
@@ -128,7 +127,7 @@ function getAccentColor(pkg: { id: string; color?: string }): string {
       <p style="margin-bottom: 1rem; line-height: 1.7; color: var(--sl-color-text);">
         RANDSUM is a TypeScript dice rolling library built for tabletop RPG developers. At its core is
         <code>@randsum/roller</code> — a zero-dependency npm package that parses and evaluates dice notation
-        with no external runtime requirements. It ships as both ESM and CommonJS and is fully typed.
+        with no external runtime requirements. It ships as ESM and is fully typed.
       </p>
       <p style="margin-bottom: 1rem; line-height: 1.7; color: var(--sl-color-text);">
         The ecosystem includes game-specific packages layered on top of the core engine.
@@ -168,7 +167,7 @@ function getAccentColor(pkg: { id: string; color?: string }): string {
             <h4>Packages</h4>
             <ul>
               <li><a href="/roller/introduction/">@randsum/roller</a></li>
-              <li><a href="/notation/introduction/">@randsum/notation</a></li>
+              <li><a href="/notation/introduction/">Dice Notation</a></li>
               <li><a href="/games/introduction/">Game Packages</a></li>
               <li><a href="/tools/claude-code-skill/">Claude Code Skill</a></li>
             </ul>

--- a/docs/adr/ADR-010-docs-site-notation-merge-alignment.md
+++ b/docs/adr/ADR-010-docs-site-notation-merge-alignment.md
@@ -1,0 +1,127 @@
+# ADR-010: Documentation Site Alignment with Notation-into-Roller Merge
+
+## Status
+
+Accepted
+
+## Context
+
+ADR-005 (merged commit `e9f7533e`) eliminated `@randsum/notation` as a separate package by merging all notation source into `@randsum/roller`. After the merge, `@randsum/roller` is zero-dependency and exports all notation functions natively — validation, parsing, transformation, tokenization, and comparison utilities are all available directly from roller subpaths and the roller main barrel.
+
+The documentation site (`apps/site/`) was authored before ADR-005 executed. At the time of the notation merge, the site contained approximately 15 files that treated `@randsum/notation` as a live, separately-installable package:
+
+- **Ecosystem overview** (`welcome/ecosystem-overview.mdx`): Shows `@randsum/notation` as the foundation layer of the dependency diagram. Describes it as a standalone package with its own `bun add @randsum/notation` install instruction. Calls roller a package that "depends on notation" and states it "re-exports three notation functions."
+- **Notation introduction** (`notation/introduction.mdx`): Page title is `@randsum/notation`. Imports reference `@randsum/notation`. Describes the package as zero-dependency and lists it as a separate npm package.
+- **Notation getting started** (`notation/getting-started.mdx`): Install instructions install `@randsum/notation`. Tips direct users to install notation separately from roller.
+- **Notation API reference** (`notation/api-reference.mdx`): Lead paragraph states that three functions "require importing from `@randsum/notation` directly."
+- **Notation validation-and-parsing** (`notation/validation-and-parsing.mdx`): Imports in examples reference `@randsum/notation`.
+- **Design principles in ecosystem overview**: States "`@randsum/notation` has no runtime dependencies; `@randsum/roller` depends only on notation."
+- **Bundle size claim**: Lists roller under 10 KB, notation under 13 KB as separate entries.
+- **Component-library tool page** (`tools/component-library.mdx`): Lists notation as a peer dependency.
+
+The mismatch between the live implementation and the documentation site creates two concrete problems:
+
+1. Developers reading the docs and following install instructions will install a deprecated package (`@randsum/notation`) instead of the live one.
+2. The ecosystem dependency diagram incorrectly depicts the package graph, which is now `@randsum/roller (zero deps) → @randsum/games`.
+
+## Decision
+
+Update all documentation site content to reflect the merged state of the codebase. The governing principles for this update are:
+
+### 1. `@randsum/notation` is not a package consumers install
+
+Remove all `bun add @randsum/notation` / `npm install @randsum/notation` install instructions. Remove all references to `@randsum/notation` as an npm package. The package is deprecated on npm; directing users to it creates a dead-end install experience.
+
+### 2. All notation imports reference `@randsum/roller`
+
+Every code example in the notation section that currently imports from `@randsum/notation` is updated to import from `@randsum/roller` or `@randsum/roller/tokenize`. The import path determines what a developer copies and runs. Wrong import paths are the highest-severity documentation error in a code-focused reference site.
+
+The mapping is:
+
+| Old import | New import |
+|---|---|
+| `from '@randsum/notation'` | `from '@randsum/roller'` |
+| `from '@randsum/notation'` (tokenize/Token) | `from '@randsum/roller/tokenize'` |
+| `from '@randsum/notation'` (comparison utils) | `from '@randsum/roller'` |
+
+### 3. The `/notation/` URL path is preserved
+
+The URL paths `randsum.dev/notation/*` stay in place. They document dice notation as a feature area of `@randsum/roller` — the notation syntax spec, validation API, parsing API, and tokenizer. Notation is a first-class concept worth dedicated documentation pages. Removing the pages or redirecting them would lose that structure.
+
+The page titles and descriptions are updated to frame the section as "Dice Notation" or "Notation in roller" rather than "`@randsum/notation` package."
+
+### 4. Roller is described as zero-dependency
+
+The ecosystem overview, roller introduction, and design-principles section are updated to state that `@randsum/roller` has zero runtime dependencies and includes notation parsing natively. The previous formulation ("depends on notation") is removed.
+
+### 5. "Re-export" language is removed
+
+The current docs describe roller as re-exporting three notation functions. This language is incorrect post-merge: roller does not re-export — it exports these functions directly. All "re-exports" phrasing is replaced with "includes" or "exports."
+
+### 6. The dependency diagram is corrected
+
+The ecosystem overview dependency diagram is updated to:
+
+```
+@randsum/roller              (zero dependencies — includes notation)
+  |
+  +-- @randsum/games         (TTRPG game packages)
+  |     +-- /blades
+  |     +-- /daggerheart
+  |     +-- /fifth
+  |     +-- /pbta
+  |     +-- /root-rpg
+  |     +-- /salvageunion
+  |
+  +-- @randsum/display-utils (UI helpers, peers on roller)
+        |
+        +-- @randsum/component-library (React components, peers on roller + react)
+```
+
+### 7. Bundle size claims are consolidated
+
+Size references that previously listed notation (13 KB) and roller (10 KB) separately are updated to reflect the current combined limit (roller 20 KB, which includes notation). Claims of "ESM + CJS" output are corrected to "ESM only."
+
+### 8. What remains a "notation-only use case"
+
+The original rationale for a separate notation package was: consumers who want validation without rolling. That use case still exists and is still served — by `@randsum/roller/tokenize` for tokenization, and by the main roller barrel for validation functions. The getting-started guide updates the install-for-validation-only use case to: "install `@randsum/roller` and use the validation functions without calling `roll()`."
+
+## Consequences
+
+### Positive
+
+- Developer-facing documentation is accurate. No developer will follow a `bun add @randsum/notation` install instruction and arrive at a deprecated package.
+- The ecosystem overview correctly represents the two-package consumer model: `@randsum/roller` for rolling (includes notation) and `@randsum/games` for game-specific mechanics.
+- The notation documentation section gains a longer useful life — it is now documentation for a feature of a maintained package, not a deprecated standalone package.
+- Import examples throughout the notation section are copy-paste correct.
+
+### Negative
+
+- The `/notation/introduction/` page no longer has an npm link at the bottom. Users who look for an npm badge or install command will not find one in the notation section (they find it in the roller section). This is a deliberate trade-off against the alternative of linking to the deprecated `@randsum/notation` npm page.
+- Developers who bookmarked or linked to notation page content expecting `@randsum/notation` install instructions will need to update their references to roller. The transition is eased by leaving a deprecation note on the `@randsum/notation` npm page pointing to roller.
+- The "notation as a separate install for lighter weight" use case disappears from the docs. This was a legitimate use case in ADR-003 but never materialized in practice (zero known external `@randsum/notation`-only consumers). Developers who need notation-only without the full roller are directed to `@randsum/roller/tokenize` or the main barrel, which tree-shakes cleanly.
+
+## Files Updated
+
+The following `apps/site/src/content/docs/` files require content changes to reflect this decision:
+
+| File | Change summary |
+|---|---|
+| `welcome/ecosystem-overview.mdx` | Dependency diagram, foundation-layer card, design principles, bundle size claims, install table |
+| `welcome/introduction.mdx` | Any reference to notation as a separate package |
+| `notation/introduction.mdx` | Page title, description, all import examples, npm link section |
+| `notation/getting-started.mdx` | Install commands, tips about notation vs roller, import examples |
+| `notation/api-reference.mdx` | Lead paragraph ("require importing from @randsum/notation directly"), all import examples |
+| `notation/validation-and-parsing.mdx` | All import examples |
+| `notation/randsum-dice-notation.mdx` | Any package-attribution language |
+| `roller/introduction.mdx` | Remove "depends on notation" / "re-exports" language; add "includes notation natively" |
+| `roller/getting-started.mdx` | Confirm no outdated notation install instructions |
+| `tools/component-library.mdx` | Remove notation from peer dependencies list if present |
+
+## References
+
+- ADR-003: Notation as Separate Package (superseded by ADR-005)
+- ADR-005: Merge @randsum/notation back into @randsum/roller (the implementation decision that necessitates this docs update)
+- Commit `e9f7533e`: refactor: merge notation into roller, streamline modifier system
+- `apps/site/src/content/docs/` — site content directory
+- `packages/roller/RANDSUM_DICE_NOTATION.md` — authoritative notation spec (source of truth for the notation reference pages)


### PR DESCRIPTION
## Summary

- Removed all references to `@randsum/notation` as a separate installable package across 11 doc site files
- Updated dependency diagram, install instructions, import paths, and bundle size claims to reflect the merged state (`@randsum/roller` is now zero-dependency with notation built in)
- Removed all "re-export" language from roller docs — notation functions are native exports
- Corrected "ESM + CJS" claims to "ESM only" throughout
- Added ADR-010 documenting the decision and governing principles

## Files Changed (12)

| File | Change |
|------|--------|
| `docs/adr/ADR-010-*` | Decision record |
| `welcome/ecosystem-overview.mdx` | Dep diagram, foundation card, sizes, ESM-only |
| `welcome/introduction.mdx` | Removed notation tab, ESM-only |
| `notation/introduction.mdx` | Retitled, imports updated, npm link removed |
| `notation/getting-started.mdx` | Install section removed, imports updated |
| `notation/api-reference.mdx` | Lead paragraph, imports updated |
| `notation/validation-and-parsing.mdx` | Description, imports updated |
| `roller/introduction.mdx` | Zero-dep claim, ESM-only JSON-LD |
| `roller/api-reference.mdx` | All re-export labels removed |
| `roller/error-handling.mdx` | Attribution updated |
| `tools/component-library.mdx` | Peer deps corrected |
| `index.astro` | Dead CSS var, ESM-only, footer link |

## Test plan

- [x] `bun run build` — all packages build
- [x] `bun run test` — 2422 pass, 0 fail
- [x] `grep -r "@randsum/notation" apps/site/src/` — zero results
- [x] `grep -r "re-export" apps/site/src/` — only correct game subpath usage remains
- [ ] Visual check: `bun run site:dev` and verify notation pages render correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)