### PR TITLE
feat: formalize repo as Claude Code plugin

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,0 +1,22 @@
+{
+  "name": "randsum",
+  "version": "1.0.0",
+  "description": "RANDSUM dice notation skills for Claude Code — roll dice, analyze probability, and create game specs for tabletop RPGs",
+  "author": {
+    "name": "RANDSUM",
+    "url": "https://randsum.dev"
+  },
+  "homepage": "https://randsum.dev",
+  "repository": "https://github.com/RANDSUM/randsum",
+  "license": "MIT",
+  "keywords": [
+    "dice",
+    "dice-roller",
+    "ttrpg",
+    "tabletop-rpg",
+    "dice-notation",
+    "dnd",
+    "probability",
+    "game-mechanics"
+  ]
+}


### PR DESCRIPTION
## Summary

Adds `.claude-plugin/plugin.json` manifest to make this repo a formal Claude Code plugin marketplace. The existing `skills/` directory (dice-rolling, dice-probability, game-spec-creator) is auto-discovered by convention — no files moved or restructured.

## Test plan

- [x] `.claude-plugin/plugin.json` has valid JSON with required `name` field
- [x] All 3 skills have `SKILL.md` files in `skills/<name>/` convention
- [x] Build and tests unaffected (no code changes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)