### PR TITLE
chore(security): override undici to >=6.27.0 (fix Security Audit)

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -167,6 +167,9 @@
       },
     },
   },
+  "overrides": {
+    "undici": ">=6.27.0",
+  },
   "catalog": {
     "@types/bun": "1.3.14",
     "@types/react": "^19.2.17",
@@ -3402,7 +3405,7 @@
 
     "uncrypto": ["uncrypto@0.1.3", "", {}, "sha512-Ql87qFHB3s/De2ClA9e0gsnS6zXG27SkTiSJwjCc9MebbfapQfuPzumMIUMi38ezPZVNFcHI9sUIepeQfw8J8Q=="],
 
-    "undici": ["undici@6.24.1", "", {}, "sha512-sC+b0tB1whOCzbtlx20fx3WgCXwkW627p4EA9uM+/tNNPkSS+eSEld6pAs9nDv7WbY1UUljBMYPtu9BCOrCWKA=="],
+    "undici": ["undici@8.5.0", "", {}, "sha512-xamtWoB1EshgjpmlXd7GGm2VfdDtw1+rD8uhry8pSNW3If6S8E0m2T2+orSKeZXEn/aPJMviCpDBA65WJt8zhg=="],
 
     "undici-types": ["undici-types@7.24.6", "", {}, "sha512-WRNW+sJgj5OBN4/0JpHFqtqzhpbnV0GuB+OozA9gCL7a993SmU+1JBZCzLNxYsbMfIeDL+lTsphD5jN5N+n0zg=="],
 

--- a/package.json
+++ b/package.json
@@ -41,6 +41,9 @@
     "@types/react": "^19.2.17",
     "@types/react-dom": "^19.2.3"
   },
+  "overrides": {
+    "undici": ">=6.27.0"
+  },
   "scripts": {
     "prepare": "[ -d .git ] && (git config --unset-all --local core.hooksPath 2>/dev/null; lefthook install) || true",
     "help": "bun scripts/help.ts",


### PR DESCRIPTION
Fixes the remaining red on main's **Security Audit** workflow.

## Problem
`bun audit --audit-level high` (what `.github/workflows/security.yml` runs) exits non-zero on one high advisory: **undici `<6.27.0`**, pulled transitively via `discord.js` into `@randsum/discord-bot` — [GHSA-vxpw-j846-p89q](https://github.com/advisories/GHSA-vxpw-j846-p89q) (WebSocket DoS via fragment-count bypass). This is independent of the `ci.yml` failures addressed in #1082.

## Fix
Add a root `overrides` pin: `"undici": ">=6.27.0"`.

## Verification
- `bun audit --audit-level high` → exit 0 (no high/critical advisories)
- `@randsum/discord-bot` (the undici consumer): build OK, tests 66 ✓ / 0 ✗
- Full pre-push suite (build, codegen, conformance, test, audit, knip, arch) passes

Stacked on `chore/audit-remediation` (#1082) so the two together take main fully green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017gQrEojx7J8oyVUhmvi71j