### PR TITLE
fix(test-utils): correct swapped advantage/disadvantage fixtures

### DIFF
--- a/packages/roller/test-utils/__tests__/fixtures.test.ts
+++ b/packages/roller/test-utils/__tests__/fixtures.test.ts
@@ -11,8 +11,8 @@ import {
 
 describe('commonNotations', () => {
   test('contains expected notation strings', () => {
-    expect(commonNotations.advantage).toBe('2d20H')
-    expect(commonNotations.disadvantage).toBe('2d20L')
+    expect(commonNotations.advantage).toBe('2d20L')
+    expect(commonNotations.disadvantage).toBe('2d20H')
     expect(commonNotations.abilityScore).toBe('4d6L')
     expect(commonNotations.damage).toBe('1d8+3')
     expect(commonNotations.skillCheck).toBe('1d20+5')
@@ -32,12 +32,12 @@ describe('commonRollOptions', () => {
     expect(commonRollOptions.advantage).toEqual({
       sides: 20,
       quantity: 2,
-      modifiers: { drop: { highest: 1 } }
+      modifiers: { drop: { lowest: 1 } }
     })
     expect(commonRollOptions.disadvantage).toEqual({
       sides: 20,
       quantity: 2,
-      modifiers: { drop: { lowest: 1 } }
+      modifiers: { drop: { highest: 1 } }
     })
   })
 })

--- a/packages/roller/test-utils/src/fixtures.ts
+++ b/packages/roller/test-utils/src/fixtures.ts
@@ -9,8 +9,8 @@ import type {
  * Common dice notation patterns for testing
  */
 export const commonNotations = {
-  advantage: '2d20H',
-  disadvantage: '2d20L',
+  advantage: '2d20L',
+  disadvantage: '2d20H',
   abilityScore: '4d6L',
   damage: '1d8+3',
   skillCheck: '1d20+5',
@@ -28,8 +28,8 @@ export const commonRollOptions = {
   d20: { sides: 20, quantity: 1 },
   d6x2: { sides: 6, quantity: 2 },
   d6x4: { sides: 6, quantity: 4 },
-  advantage: { sides: 20, quantity: 2, modifiers: { drop: { highest: 1 } } },
-  disadvantage: { sides: 20, quantity: 2, modifiers: { drop: { lowest: 1 } } }
+  advantage: { sides: 20, quantity: 2, modifiers: { drop: { lowest: 1 } } },
+  disadvantage: { sides: 20, quantity: 2, modifiers: { drop: { highest: 1 } } }
 } as const
 
 /**


### PR DESCRIPTION
The `commonNotations` and `commonRollOptions` test fixtures had **advantage and disadvantage reversed**.

In RANDSUM notation, `L` drops the lowest die (keeps the higher → **advantage**) and `H` drops the highest (keeps the lower → **disadvantage**). Verified empirically: `2d20L` averages ≈13.8, `2d20H` averages ≈7.2.

## Changes (`packages/roller/test-utils/`)
- `commonNotations.advantage`: `2d20H` → `2d20L`; `disadvantage`: `2d20L` → `2d20H`
- `commonRollOptions.advantage`: `drop.highest` → `drop.lowest`; `disadvantage`: `drop.lowest` → `drop.highest`
- Updated `fixtures.test.ts` assertions to match

Test-only fixtures — no production roll logic is affected. (Found during the docs-accuracy pass in #1085.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017gQrEojx7J8oyVUhmvi71j