### PR TITLE
chore(release): publish via npm OIDC Trusted Publishing

### DIFF
--- a/.changeset/verify-oidc-publish.md
+++ b/.changeset/verify-oidc-publish.md
@@ -1,0 +1,5 @@
+---
+"@randsum/games": patch
+---
+
+Verify the npm OIDC Trusted Publishing release pipeline end-to-end. No functional or API change — release-infrastructure smoke test only.

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -2,7 +2,8 @@ name: Release
 
 # SECURITY — workflow_run safe-usage invariant (audit L7 / security F3).
 # `workflow_run` runs in the PRIVILEGED base-repo context with access to
-# NPM_TOKEN / GITHUB_TOKEN and contents:write + id-token:write. To avoid a
+# GITHUB_TOKEN + the OIDC id-token (used for npm Trusted Publishing) and
+# contents:write + id-token:write. To avoid a
 # "pwn-request" exposure this job MUST:
 #   - only ever check out trusted DEFAULT-BRANCH code (the bare `actions/checkout`
 #     below resolves to the default branch in workflow_run context — never pass a
@@ -52,6 +53,6 @@ jobs:
           title: 'chore: version packages'
           commit: 'chore: version packages'
         env:
+          # No NPM_TOKEN/NODE_AUTH_TOKEN: npm authenticates via OIDC Trusted
+          # Publishing (id-token: write above). A token here would override OIDC.
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/scripts/publish.ts
+++ b/scripts/publish.ts
@@ -9,8 +9,10 @@
  *   bun run publish -- --otp=123456  # provide 2FA OTP (local only)
  *
  * Uses `bun pm pack` to resolve workspace: protocols, then `npm publish`
- * on the tarball. In CI, auth and provenance are handled automatically
- * by npm Trusted Publishers (OIDC). Requires npm >= 11.5.1, Node >= 22.14.
+ * on the tarball. In CI, auth is handled by npm Trusted Publishing (OIDC) —
+ * no NPM_TOKEN — and `--provenance` (added only under GITHUB_ACTIONS) attests
+ * the build to the workflow run. Local publishes omit provenance and use
+ * `--otp`. Requires npm >= 11.5.1, Node >= 22.14, `id-token: write` on the job.
  *
  * Publishes workspace packages in dependency order, skips private ones.
  */
@@ -106,6 +108,10 @@ for (const { name, dir } of packages) {
     }
 
     const npmArgs = ['publish', tgzPath, '--access=public']
+    // Provenance requires an OIDC-capable CI; skip it for local --otp publishes.
+    if (process.env['GITHUB_ACTIONS'] === 'true') {
+      npmArgs.push('--provenance')
+    }
     for (const arg of extraArgs) {
       npmArgs.push(arg)
     }


### PR DESCRIPTION
## Why

The Release workflow 404'd publishing `@randsum/games` because the `NPM_TOKEN` secret (last set 2022-07-23) was a stale/expired token. npm now only issues **granular tokens with a 90-day max lifetime**, so any token-based `NPM_TOKEN` is a recurring expiry trap — it *will* break again on a timer.

OIDC **Trusted Publishing** removes the long-lived token entirely: GitHub Actions authenticates per-run via a short-lived OIDC id-token. The npm-side trusted publisher is already configured for `RANDSUM/randsum` → `publish.yml`, and the workflow already grants `id-token: write`.

## Changes

- **`publish.yml`** — drop `NPM_TOKEN` / `NODE_AUTH_TOKEN` from the Release job env. A token present in the env overrides OIDC, so it must be removed for npm to use the OIDC exchange. (`GITHUB_TOKEN` stays — changesets needs it.)
- **`scripts/publish.ts`** — add `--provenance`, guarded by `GITHUB_ACTIONS` so local `bun publish --otp` keeps working (provenance requires an OIDC-capable CI).
- Updated the security-invariant comment to reflect token → OIDC.

## Follow-up (npm side, manual)

- Confirm the trusted publisher is configured for **all three** published packages: `@randsum/roller`, `@randsum/games`, `@randsum/cli` (each package has its own publishing-access config). Screenshot confirmed at least one.
- The old `NPM_TOKEN` secret can be deleted once a real publish succeeds via OIDC.

## Validation

- `bun run build`, typecheck, lint, format all pass (pre-commit hooks green).
- OIDC publish can only be exercised by an actual version bump, so the first real publish post-merge is the live test. Token-skip behavior for already-published versions is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)