### PR TITLE
ci(netlify): conserve build minutes on the free Starter tier

### DIFF
--- a/apps/rdn/netlify.toml
+++ b/apps/rdn/netlify.toml
@@ -2,6 +2,13 @@
   base = "."
   command = "bun run --filter @randsum/roller build && bun run --filter @randsum/rdn build"
   publish = "apps/rdn/dist"
+  # Skip the build (exit 0) when no changes touched this site or its build inputs,
+  # conserving free-tier build minutes. rdn only depends on @randsum/roller, so it
+  # rebuilds on changes to apps/rdn, packages/roller, or root build config (lockfile,
+  # workspace + tsconfig). `git diff --quiet` exits 1 when those paths changed →
+  # build proceeds. On the first build CACHED_COMMIT_REF is empty and git errors
+  # non-zero, so the build also proceeds (safe default).
+  ignore = "git diff --quiet $CACHED_COMMIT_REF $COMMIT_REF -- apps/rdn packages/roller package.json bun.lock tsconfig.json tsconfig.packages.json"
 
 [build.environment]
   # Pin the build toolchain so Netlify deploys are reproducible (audit X4 /

--- a/apps/site/netlify.toml
+++ b/apps/site/netlify.toml
@@ -3,6 +3,15 @@
   # Builds packages first (for workspace resolution), generates API docs, then builds the site
   command = "bun run build && bun run site:build"
   publish = "apps/site/dist"
+  # Skip the build (exit 0) when no changes touched this site or its build inputs,
+  # conserving free-tier build minutes. The site documents the whole ecosystem and
+  # generates API docs (typedoc) from every package, so it rebuilds on changes to
+  # apps/site, any packages/*, or root build config (lockfile, workspace + tsconfig +
+  # typedoc). It does NOT rebuild for changes confined to the other apps (rdn, cli,
+  # expo, discord-bot). `git diff --quiet` exits 1 when the listed paths changed →
+  # build proceeds. On the first build CACHED_COMMIT_REF is empty and git errors
+  # non-zero, so the build also proceeds (safe default).
+  ignore = "git diff --quiet $CACHED_COMMIT_REF $COMMIT_REF -- apps/site packages package.json bun.lock tsconfig.json tsconfig.packages.json tsconfig.typedoc.json typedoc.json"
 
 [build.environment]
   # Pin the build toolchain so Netlify deploys are reproducible (audit X4 /

--- a/apps/site/netlify.toml
+++ b/apps/site/netlify.toml
@@ -1,17 +1,20 @@
 [build]
-  # Build command runs from root (base directory)
-  # Builds packages first (for workspace resolution), generates API docs, then builds the site
-  command = "bun run build && bun run site:build"
+  # Build command runs from root (base directory). The site imports @randsum/roller
+  # and @randsum/games (via subpath exports, so both must be built first); it does
+  # NOT import @randsum/cli or @randsum/discord-bot (those appear only in MDX prose).
+  # So build just roller + games rather than the full `bun run build`, conserving
+  # free-tier build minutes. roller is built before games because games depends on it.
+  command = "bun run --filter '@randsum/roller' build && bun run --filter '@randsum/games' build && bun run site:build"
   publish = "apps/site/dist"
   # Skip the build (exit 0) when no changes touched this site or its build inputs,
-  # conserving free-tier build minutes. The site documents the whole ecosystem and
-  # generates API docs (typedoc) from every package, so it rebuilds on changes to
-  # apps/site, any packages/*, or root build config (lockfile, workspace + tsconfig +
-  # typedoc). It does NOT rebuild for changes confined to the other apps (rdn, cli,
-  # expo, discord-bot). `git diff --quiet` exits 1 when the listed paths changed →
-  # build proceeds. On the first build CACHED_COMMIT_REF is empty and git errors
-  # non-zero, so the build also proceeds (safe default).
-  ignore = "git diff --quiet $CACHED_COMMIT_REF $COMMIT_REF -- apps/site packages package.json bun.lock tsconfig.json tsconfig.packages.json tsconfig.typedoc.json typedoc.json"
+  # conserving free-tier build minutes. The site imports roller + games and renders
+  # MDX docs for the whole ecosystem, so it rebuilds on changes to apps/site, any
+  # packages/*, or root build config (lockfile, workspace + tsconfig). It does NOT
+  # rebuild for changes confined to the other apps (rdn, cli, expo, discord-bot).
+  # `git diff --quiet` exits 1 when the listed paths changed → build proceeds. On the
+  # first build CACHED_COMMIT_REF is empty and git errors non-zero, so the build also
+  # proceeds (safe default).
+  ignore = "git diff --quiet $CACHED_COMMIT_REF $COMMIT_REF -- apps/site packages package.json bun.lock tsconfig.json tsconfig.packages.json"
 
 [build.environment]
   # Pin the build toolchain so Netlify deploys are reproducible (audit X4 /


### PR DESCRIPTION
Both docs sites (`randsum.dev`, `notation.randsum.dev`) moved from the Pro team to the free **Starter** tier (`nf_team_dev`). Build minutes drop from ~25,000/mo to ~300/mo, so this PR adds two guardrails to keep deploys affordable.

## 1. Skip builds when a site's inputs are unchanged (`ignore`)

Neither `netlify.toml` had an `ignore` command, so every monorepo push rebuilt both sites. Now each site only rebuilds when its own build inputs change:

| Site | Rebuilds when these paths change |
|------|----------------------------------|
| `apps/rdn` (notation.randsum.dev) | `apps/rdn`, `packages/roller`, root build config (lockfile, workspace + tsconfig) |
| `apps/site` (randsum.dev) | `apps/site`, **any** `packages/*`, root build config |

`git diff --quiet` exits **0 → skip build** when none of the listed paths changed, **1 → build** otherwise. On the first build `CACHED_COMMIT_REF` is empty so git errors non-zero and the build proceeds (safe default). Validated against a real `packages/games` commit: rdn correctly **skips**, site correctly **builds**.

## 2. Build only what the site imports, not the whole monorepo

The site's command ran the full `bun run build`, compiling roller, games, cli, **and discord-bot** on every deploy. But the site only imports `@randsum/roller` (181×) and `@randsum/games` (151×, via subpath exports → both must be built). `@randsum/cli` (10×) and `@randsum/discord-bot` (1×) appear only in MDX prose/code samples — never imported.

Trimmed to `roller → games → site`. **Verified locally**: with `apps/cli/dist` and `apps/discord-bot/dist` deleted, `astro build` still produces all 32 pages.

## Note

The 1 concurrent build cap on free tier isn't configurable — a shared `packages/roller` change legitimately rebuilds both sites and they serialize. These two changes minimize how often that happens and how long each build runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)