### PR TITLE
fix(release): stop setup-node from shadowing OIDC with a placeholder token

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -35,8 +35,11 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
       - uses: ./.github/actions/bun-setup
         with:
+          # No registry-url: that makes setup-node write an .npmrc _authToken line
+          # (with a placeholder token) which shadows OIDC Trusted Publishing. The
+          # committed root .npmrc already sets registry=registry.npmjs.org, so npm
+          # targets the right registry and authenticates purely via OIDC.
           node-version: '24'
-          registry-url: 'https://registry.npmjs.org'
       - name: Install latest npm
         run: npm install -g npm@latest
       - name: Build all packages


### PR DESCRIPTION
## What happened

After #1088 switched the Release workflow to OIDC Trusted Publishing, the first real publish (`@randsum/games@3.0.1`, run [28071110708](https://github.com/RANDSUM/randsum/actions/runs/28071110708)) still **404'd** on the registry PUT — even though npm successfully **signed a provenance statement via the GitHub Actions OIDC id-token** (proving the id-token plumbing works).

## Root cause

`bun-setup` passes `registry-url` to `actions/setup-node`, which:
- writes an `.npmrc` line `//registry.npmjs.org/:_authToken=${NODE_AUTH_TOKEN}`, and
- injects a placeholder `NODE_AUTH_TOKEN=XXXXX-XXXXX-XXXXX-XXXXX` into the job env.

npm reads that placeholder token and uses it for the registry PUT **instead of performing the OIDC exchange** → 404. Removing `NODE_AUTH_TOKEN` from the changesets *step* (in #1088) didn't help because `setup-node` re-creates it.

## Fix

Drop `registry-url` from the `bun-setup` call in `publish.yml`. `setup-node` then writes no auth line. The committed root `.npmrc` already sets `registry=https://registry.npmjs.org/`, so npm still targets the right registry and now authenticates purely via OIDC.

## Validation

The OIDC publish path can only be exercised by a real version bump, so the live test is the next release after merge. Provenance signing already succeeded, so the id-token side is confirmed; this clears the registry-auth side.

> [!NOTE]
> If a publish still 404s after this, the remaining suspect is the `@randsum/games` trusted-publisher config on npm — verify Org/repo = `RANDSUM/randsum`, workflow = `publish.yml`, and **Environment = blank** (the job sets no `environment:`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)