### PR TITLE
feat(cli): unknown-flag detection, did-you-mean suggestions, --total flag; fix advantage doc

### DIFF
--- a/.changeset/cli-flags-polish.md
+++ b/.changeset/cli-flags-polish.md
@@ -1,0 +1,13 @@
+---
+"@randsum/cli": minor
+---
+
+Add scripting-friendly flags and clearer error handling to the CLI:
+
+- **Unknown-flag detection** — an unrecognized `-`/`--` argument (e.g. `--jsn`)
+  now prints a clear `Unknown flag` message and exits 1 instead of being treated
+  as dice notation and producing a confusing parse error.
+- **Did-you-mean suggestions** — invalid notation errors now append roller's
+  `suggestNotationFix` hint (e.g. `Did you mean \`1d20\`?`), matching the Discord bot.
+- **`-t`, `--total`** — print only the numeric total per roll (one per line),
+  for scripting. Composes with `-r`; cannot be combined with `--json`.

--- a/apps/cli/__tests__/e2e.test.ts
+++ b/apps/cli/__tests__/e2e.test.ts
@@ -83,6 +83,46 @@ describe('@randsum/cli e2e (built binary)', () => {
     expect(stderr).toContain('Error:')
   })
 
+  test('unknown flag exits non-zero with a clear message (not a parse error)', () => {
+    const { stderr, exitCode } = runCli(['4d6L', '--jsn'])
+    expect(exitCode).toBe(1)
+    expect(stderr).toContain('Unknown flag: --jsn')
+    expect(stderr).not.toContain('not valid dice notation')
+  })
+
+  test('--total prints only the numeric total', () => {
+    const { stdout, exitCode } = runCli(['3d6', '--total', '--seed', '42'])
+    expect(exitCode).toBe(0)
+    expect(stdout).toMatch(/^\d+$/)
+  })
+
+  test('-t with --repeat prints one total per line', () => {
+    const { stdout, exitCode } = runCli(['1d6', '-t', '-r', '3', '--seed', '42'])
+    expect(exitCode).toBe(0)
+    const lines = stdout.split('\n').filter(Boolean)
+    expect(lines).toHaveLength(3)
+    for (const line of lines) {
+      expect(line).toMatch(/^\d+$/)
+    }
+  })
+
+  test('--total combined with --json is rejected', () => {
+    const { stderr, exitCode } = runCli(['3d6', '--total', '--json'])
+    expect(exitCode).toBe(1)
+    expect(stderr).toContain('Cannot combine --total with --json')
+  })
+
+  test('--json with -r emits JSON-lines (one object per line)', () => {
+    const { stdout, exitCode } = runCli(['2d6', '--json', '-r', '2', '--seed', '42'])
+    expect(exitCode).toBe(0)
+    const lines = stdout.split('\n').filter(Boolean)
+    expect(lines).toHaveLength(2)
+    for (const line of lines) {
+      const parsed = JSON.parse(line) as { total: number }
+      expect(typeof parsed.total).toBe('number')
+    }
+  })
+
   test('--help exits 0 and prints usage', () => {
     const { stdout, exitCode } = runCli(['--help'])
     expect(exitCode).toBe(0)

--- a/apps/cli/__tests__/index.test.ts
+++ b/apps/cli/__tests__/index.test.ts
@@ -32,6 +32,12 @@ describe('main() mode dispatch', () => {
     expect(consoleSpy.log).toHaveBeenCalled()
   })
 
+  test('--help documents the --total flag', () => {
+    main(['node', 'randsum', '--help'])
+    const output = consoleSpy.log?.mock.calls[0]?.[0] as string
+    expect(output).toContain('--total')
+  })
+
   test('--version flag prints version and returns', () => {
     main(['node', 'randsum', '--version'])
     expect(consoleSpy.log).toHaveBeenCalled()

--- a/apps/cli/__tests__/run.test.ts
+++ b/apps/cli/__tests__/run.test.ts
@@ -64,6 +64,35 @@ describe('runRolls', () => {
     expect(a.stdout).toBe(b.stdout)
   })
 
+  test('prints only the numeric total when total flag set', () => {
+    const result = runRolls({
+      notations: ['3d6'],
+      verbose: false,
+      json: false,
+      total: true,
+      repeat: 1,
+      seed: 42
+    })
+    expect(result.stdout).toMatch(/^\d+$/)
+    expect(result.hadError).toBe(false)
+  })
+
+  test('total flag prints one total per line with repeat', () => {
+    const result = runRolls({
+      notations: ['1d6'],
+      verbose: false,
+      json: false,
+      total: true,
+      repeat: 3,
+      seed: 42
+    })
+    const lines = result.stdout.split('\n').filter(Boolean)
+    expect(lines).toHaveLength(3)
+    for (const line of lines) {
+      expect(line).toMatch(/^\d+$/)
+    }
+  })
+
   test('routes errors to stderr and flags hadError', () => {
     const result = runRolls({
       notations: ['zzzz'],
@@ -73,6 +102,18 @@ describe('runRolls', () => {
     })
     expect(result.stderr).toContain('Error:')
     expect(result.stdout).toBe('')
+    expect(result.hadError).toBe(true)
+  })
+
+  test('appends a did-you-mean suggestion when one is available', () => {
+    const result = runRolls({
+      notations: ['d20+'],
+      verbose: false,
+      json: false,
+      repeat: 1
+    })
+    expect(result.stderr).toContain('Error:')
+    expect(result.stderr).toContain('Did you mean')
     expect(result.hadError).toBe(true)
   })
 

--- a/apps/cli/__tests__/run.test.ts
+++ b/apps/cli/__tests__/run.test.ts
@@ -117,6 +117,30 @@ describe('runRolls', () => {
     expect(result.hadError).toBe(true)
   })
 
+  test('suggests a fix for the invalid notation, not the joined args', () => {
+    const result = runRolls({
+      notations: ['2d6+3', '1d8zz'],
+      verbose: false,
+      json: false,
+      repeat: 1
+    })
+    expect(result.stderr).toContain('Did you mean `1d8`?')
+    expect(result.stderr).not.toContain('2d6+31d8zz')
+    expect(result.hadError).toBe(true)
+  })
+
+  test('omits a suggestion when the invalid notation has no sensible fix', () => {
+    const result = runRolls({
+      notations: ['1d6', 'zzzz'],
+      verbose: false,
+      json: false,
+      repeat: 1
+    })
+    expect(result.stderr).toContain('Error:')
+    expect(result.stderr).not.toContain('Did you mean')
+    expect(result.hadError).toBe(true)
+  })
+
   test('supports multiple notations', () => {
     const result = runRolls({
       notations: ['1d6', '1d8'],

--- a/apps/cli/src/index.ts
+++ b/apps/cli/src/index.ts
@@ -12,7 +12,8 @@ Arguments:
 
 Flags:
   -v, --verbose     Show detailed roll breakdown
-  --json            Output as JSON
+  --json            Output as JSON (with -r: JSON-lines, one object per line)
+  -t, --total       Print only the numeric total (one per line, for scripting)
   -r, --repeat N    Roll N times
   -s, --seed N      Use seeded random
   -h, --help        Show this help
@@ -23,16 +24,19 @@ Examples:
   randsum 2d20L +5         Roll with advantage + modifier
   randsum 1d20 -v          Verbose output
   randsum 3d6 --json       JSON output
-  randsum 4d6L -r 6        Roll 6 times`
+  randsum 4d6L -r 6        Roll 6 times
+  randsum 3d6 -t           Print only the total`
 
 interface ParsedArgs {
   readonly notations: string[]
   readonly verbose: boolean
   readonly json: boolean
+  readonly total: boolean
   readonly repeat: number
   readonly seed: number | undefined
   readonly help: boolean
   readonly version: boolean
+  readonly error: string | undefined
 }
 
 function parseArgs(argv: readonly string[]): ParsedArgs {
@@ -40,10 +44,12 @@ function parseArgs(argv: readonly string[]): ParsedArgs {
   const flags = {
     verbose: false,
     json: false,
+    total: false,
     repeat: 1,
     seed: undefined as number | undefined,
     help: false,
-    version: false
+    version: false,
+    error: undefined as string | undefined
   }
 
   const args = argv.slice(2)
@@ -52,6 +58,8 @@ function parseArgs(argv: readonly string[]): ParsedArgs {
       flags.verbose = true
     } else if (arg === '--json') {
       flags.json = true
+    } else if (arg === '-t' || arg === '--total') {
+      flags.total = true
     } else if (arg === '-r' || arg === '--repeat') {
       flags.repeat = Number(args[i + 1]) || 1
     } else if (arg === '-s' || arg === '--seed') {
@@ -70,9 +78,19 @@ function parseArgs(argv: readonly string[]): ParsedArgs {
         args[i - 1] === '--seed')
     ) {
       // Skip — already consumed as flag value
+    } else if (arg.startsWith('-') && !/^-\d/.test(arg)) {
+      // Looks like a flag but is not recognized. Negative numbers (`-5`) are
+      // excluded so they still flow to notation validation rather than being
+      // mislabeled as flags.
+      flags.error =
+        flags.error ?? `Unknown flag: ${arg}\n\nRun 'randsum --help' to see available flags.`
     } else {
       notations.push(arg)
     }
+  }
+
+  if (flags.total && flags.json) {
+    flags.error = flags.error ?? 'Cannot combine --total with --json. Use one or the other.'
   }
 
   return { notations, ...flags }
@@ -101,6 +119,11 @@ export function main(argv: readonly string[]): void {
     return
   }
 
+  if (parsed.error) {
+    console.error(parsed.error)
+    process.exit(1)
+  }
+
   const stdinNotations =
     parsed.notations.length === 0 && !process.stdin.isTTY
       ? readStdinSync().split(/\s+/).filter(Boolean)
@@ -117,6 +140,7 @@ export function main(argv: readonly string[]): void {
     notations,
     verbose: parsed.verbose,
     json: parsed.json,
+    total: parsed.total,
     repeat: parsed.repeat,
     seed: parsed.seed
   })

--- a/apps/cli/src/run.ts
+++ b/apps/cli/src/run.ts
@@ -1,6 +1,7 @@
 import type { RollArgument, RollConfig, RollerRollResult } from '@randsum/roller'
 import { suggestNotationFix } from '@randsum/roller'
 import { roll } from '@randsum/roller/roll'
+import { isDiceNotation } from '@randsum/roller/validate'
 import { formatCompact, formatJson, formatVerbose } from './format'
 
 interface RunOptions {
@@ -52,7 +53,8 @@ export function runRolls(options: RunOptions): RunResult {
       stdoutLines.push(format(result))
     } catch (e) {
       const baseMessage = `Error: ${e instanceof Error ? e.message : String(e)}`
-      const suggestion = suggestNotationFix(options.notations.join(' '))
+      const invalidNotation = options.notations.find(notation => !isDiceNotation(notation))
+      const suggestion = invalidNotation ? suggestNotationFix(invalidNotation) : undefined
       stderrLines.push(
         suggestion ? `${baseMessage}\n\nDid you mean \`${suggestion}\`?` : baseMessage
       )

--- a/apps/cli/src/run.ts
+++ b/apps/cli/src/run.ts
@@ -1,4 +1,5 @@
-import type { RollArgument, RollConfig } from '@randsum/roller'
+import type { RollArgument, RollConfig, RollerRollResult } from '@randsum/roller'
+import { suggestNotationFix } from '@randsum/roller'
 import { roll } from '@randsum/roller/roll'
 import { formatCompact, formatJson, formatVerbose } from './format'
 
@@ -6,6 +7,7 @@ interface RunOptions {
   readonly notations: readonly string[]
   readonly verbose: boolean
   readonly json: boolean
+  readonly total?: boolean
   readonly repeat: number
   readonly seed?: number | undefined
 }
@@ -31,7 +33,13 @@ export function runRolls(options: RunOptions): RunResult {
   const config: RollConfig | undefined =
     options.seed !== undefined ? { randomFn: createSeededRandom(options.seed) } : undefined
 
-  const format = options.json ? formatJson : options.verbose ? formatVerbose : formatCompact
+  const format = options.total
+    ? (result: RollerRollResult): string => String(result.total)
+    : options.json
+      ? formatJson
+      : options.verbose
+        ? formatVerbose
+        : formatCompact
 
   const stdoutLines: string[] = []
   const stderrLines: string[] = []
@@ -43,7 +51,11 @@ export function runRolls(options: RunOptions): RunResult {
       const result = config ? roll(...notations, config) : roll(...notations)
       stdoutLines.push(format(result))
     } catch (e) {
-      stderrLines.push(`Error: ${e instanceof Error ? e.message : String(e)}`)
+      const baseMessage = `Error: ${e instanceof Error ? e.message : String(e)}`
+      const suggestion = suggestNotationFix(options.notations.join(' '))
+      stderrLines.push(
+        suggestion ? `${baseMessage}\n\nDid you mean \`${suggestion}\`?` : baseMessage
+      )
     }
   }
 

--- a/apps/site/src/content/docs/tools/cli.mdx
+++ b/apps/site/src/content/docs/tools/cli.mdx
@@ -41,7 +41,8 @@ randsum 4d6L -r 6        # Roll 6 times`} />
 | Flag | Description |
 |---|---|
 | `-v`, `--verbose` | Show detailed roll breakdown (raw dice, kept dice, total) |
-| `--json` | Output result as JSON |
+| `--json` | Output result as JSON. With `-r`, emits JSON-lines (one object per line) |
+| `-t`, `--total` | Print only the numeric total, one per line (for scripting). Cannot combine with `--json` |
 | `-r N`, `--repeat N` | Roll N times and print each result |
 | `-s N`, `--seed N` | Use a seeded random number generator for reproducible results |
 | `-h`, `--help` | Show help text |
@@ -86,13 +87,31 @@ Structured JSON output. Useful for piping into other tools.
 }
 ```
 
+When combined with `-r N`, `--json` emits **JSON-lines** — one JSON object per
+line rather than a single array — so you can stream each roll into `jq`:
+
+<CodeExample lang="bash" code={`randsum 4d6L --json -r 6 | jq '.total'`} />
+
+### Total (`-t`)
+
+Prints only the numeric total, one per line. Ideal for scripting — no brackets,
+labels, or JSON to parse. Composes with `-r` (one total per line) but cannot be
+combined with `--json`.
+
+```
+14
+```
+
 ## Examples
 
 <CodeExample lang="bash" code={`# D&D ability score generation — roll 6 sets of 4d6 drop lowest
 randsum 4d6L -r 6
 
-# Advantage roll — two d20s, keep highest, plus 5
-randsum 2d20H +5
+# Advantage roll — two d20s, drop the lowest (keep highest)
+randsum 2d20L
+
+# Disadvantage roll — two d20s, drop the highest (keep lowest)
+randsum 2d20H
 
 # Seeded roll for reproducible results
 randsum 2d6 -s 42
@@ -101,7 +120,13 @@ randsum 2d6 -s 42
 randsum 2d6+3 1d8
 
 # JSON output for scripting
-randsum 4d6L --json | jq '.total'`} />
+randsum 4d6L --json | jq '.total'
+
+# JSON-lines: one object per repeat, streamed into jq
+randsum 4d6L --json -r 6 | jq '.total'
+
+# Total-only output for shell scripts
+randsum 4d6L -t -r 6`} />
 
 ## Links
 


### PR DESCRIPTION
## Summary

Scripting-friendly polish for `@randsum/cli`, plus a docs correction. Scope: `apps/cli/**` and `apps/site/src/content/docs/tools/cli.mdx`.

- **Unknown-flag detection** (`src/index.ts` `parseArgs`): an argument that looks like a flag (`-`/`--`) but is not recognized (e.g. `--jsn`) now prints a clear `Unknown flag: <flag>` message to stderr and exits 1, instead of being treated as dice notation and producing a confusing `"--jsn" is not valid dice notation` parse error. Negative numbers (`-5`) are excluded from the check so they still flow to notation validation.
- **Did-you-mean suggestions** (`src/run.ts`): the error path now wires roller's public `suggestNotationFix`, matching the Discord bot. Invalid notation appends `Did you mean \`<fix>\`?` when a suggestion is available. Verified `suggestNotationFix` is importable from the `@randsum/roller` public entry (`packages/roller/src/index.ts`).
- **`-t`, `--total`**: prints only the numeric total per roll (one per line) for scripting. Composes with `--repeat` (one total per line) and is rejected when combined with `--json` (`Cannot combine --total with --json`).
- **Docs fix** (`cli.mdx`): the advantage example taught `2d20H`, but `H` drops the **highest** — that is disadvantage. Advantage is `2d20L`. Corrected, and added a matching disadvantage example. Also documented that `--json` with `-r` emits **JSON-lines** (one object per line, pipe to `jq`) and documented `--total`. (The `--help` text at `src/index.ts` was already correct on advantage; it now additionally documents `--total` and the JSON-lines behavior.)
- **Tests**: added coverage for `--total` output, `--total` + `--repeat`, the `--total`/`--json` rejection, unknown-flag detection, the did-you-mean suggestion, and JSON-lines under `-r` (`__tests__/run.test.ts`, `__tests__/e2e.test.ts`, `__tests__/index.test.ts`).
- **Changeset**: `minor` bump for `@randsum/cli`.

## Verification

Run in the worktree:

- `bun run --filter @randsum/cli test` — 35 pass, 0 fail
- `bun run --filter @randsum/cli typecheck` — clean
- `bun run --filter @randsum/cli lint` — clean
- `bun run --filter @randsum/cli build` — succeeds (after building `@randsum/roller`, whose built package the new value import resolves)
- Manual: `--jsn` -> `Unknown flag`; `3d6 -t` -> total only; `1d6 -t -r 3` -> three totals; `3d6 -t --json` -> rejected; `2d6 --json -r 2` -> JSON-lines; invalid notation -> did-you-mean hint.

Pre-commit and pre-push hooks (build, codegen-check, conformance-check, test, audit, sca, knip, arch-check) all passed on push.

From the 2026-07-07 monorepo deep-dive audit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019DMVgLnWbodhurNKcGM1oz