### PR TITLE
feat: give fate full surfaces — /fate command, docs page, landing data, seven systems

### DIFF
--- a/apps/discord-bot/LISTING.md
+++ b/apps/discord-bot/LISTING.md
@@ -10,28 +10,29 @@ RANDSUM.io
 
 ## Short Description (max 100–150 chars)
 
-Roll dice for D&D, Blades in the Dark, Daggerheart, PbtA, Root RPG, and Salvage Union directly in Discord.
+Roll dice for D&D, Blades in the Dark, Daggerheart, Fate Core, PbtA, Root RPG, and Salvage Union directly in Discord.
 
 ## Long Description
 
-RANDSUM is a fully-featured dice rolling bot for tabletop RPG sessions. Built on the open-source [@randsum/roller](https://github.com/RANDSUM/randsum) library, it supports the full RANDSUM dice notation system and provides dedicated slash commands for six popular game systems.
+RANDSUM is a fully-featured dice rolling bot for tabletop RPG sessions. Built on the open-source [@randsum/roller](https://github.com/RANDSUM/randsum) library, it supports the full RANDSUM dice notation system and provides dedicated slash commands for seven popular game systems.
 
 ### Supported Game Systems
 
 - **D&D 5th Edition** (`/fifth`) — d20 + modifier with advantage and disadvantage. Natural 20 highlighted in gold, natural 1 in crimson.
 - **Blades in the Dark** (`/blades`) — Action dice pool with critical, success, partial success, and failure outcomes.
 - **Daggerheart** (`/dh`) — Hope and fear dice with modifiers, advantage/disadvantage, and die amplification.
+- **Fate Core** (`/fate`) — 4dF + skill resolved against the Fate ladder, from Terrible up to Legendary.
 - **Powered by the Apocalypse** (`/pbta`) — 2d6 + stat with forward and ongoing bonuses. Miss, weak hit, and strong hit outcomes.
 - **Root RPG** (`/root`) — 2d6 + bonus with strong hit, weak hit, and miss resolution.
 - **Salvage Union** (`/su`) — d20 table lookups including Core Mechanic and Morale tables.
 
 ### Key Features
 
-- **Full notation support** — Roll any combination using RANDSUM dice notation: drop lowest/highest, reroll, explode, cap, and more. Examples: `4d6L`, `2d20H`, `3d8+5`, `4d6!>5`.
+- **Full notation support** — Roll any combination using RANDSUM dice notation: drop lowest/highest, reroll, explode, cap, and more. Examples: `4d6L`, `2d20H`, `3d8+5`, `4d6!{>5}`.
 - **Detailed breakdowns** — Every result shows individual die values, which dice were kept or dropped, modifiers applied, and the final total.
 - **Color-coded embeds** — Outcomes are visually distinct. Critical hits, failures, and special results each have their own color and formatting.
 - **Zero configuration** — Add the bot and start rolling immediately. No setup, no permissions fiddling, no configuration commands.
-- **Nine slash commands** — All commands are registered as Discord slash commands with autocomplete and inline help.
+- **Ten slash commands** — All commands are registered as Discord slash commands with autocomplete and inline help.
 
 ### Commands
 
@@ -41,6 +42,7 @@ RANDSUM is a fully-featured dice rolling bot for tabletop RPG sessions. Built on
 | `/fifth [modifier] [rolling_with]`                            | D&D 5e d20 roll with optional advantage/disadvantage |
 | `/blades dice:<n>`                                            | Blades in the Dark action roll                       |
 | `/dh [modifier] [rolling_with] [amplify_hope] [amplify_fear]` | Daggerheart hope and fear dice                       |
+| `/fate [skill]`                                               | Fate Core 4dF + skill against the ladder             |
 | `/root [modifier]`                                            | Root RPG 2d6 + modifier                              |
 | `/su [table]`                                                 | Salvage Union table roll                             |
 | `/pbta stat:<n> [forward] [ongoing] [rolling_with]`           | PbtA 2d6 move roll                                   |
@@ -58,7 +60,7 @@ RANDSUM is a fully-featured dice rolling bot for tabletop RPG sessions. Built on
 
 ## Tags
 
-`dice` `dice-roller` `ttrpg` `dnd` `tabletop` `rpg` `blades-in-the-dark` `daggerheart` `pbta` `root-rpg` `salvage-union` `5e`
+`dice` `dice-roller` `ttrpg` `dnd` `tabletop` `rpg` `blades-in-the-dark` `daggerheart` `fate` `pbta` `root-rpg` `salvage-union` `5e`
 
 ## Category
 

--- a/apps/discord-bot/__tests__/commands/fate.test.ts
+++ b/apps/discord-bot/__tests__/commands/fate.test.ts
@@ -1,0 +1,109 @@
+import { beforeEach, describe, expect, mock, test } from 'bun:test'
+import type { APIEmbed } from 'discord.js'
+
+const mockRoll = mock((): { result: string; total: number; rolls: unknown[] } => ({
+  result: 'Great',
+  total: 4,
+  rolls: [{ initialRolls: [1, 1, 0, 1], rolls: [1, 1, 0, 1], modifierLogs: [] }]
+}))
+
+void mock.module('@randsum/games/fate', () => ({ roll: mockRoll }))
+
+const { fateCommand } = await import('../../src/commands/fate.js')
+
+function makeInteraction(
+  opts: {
+    skill?: number
+  } = {}
+): {
+  deferReply: ReturnType<typeof mock>
+  editReply: ReturnType<typeof mock>
+  options: {
+    getInteger: ReturnType<typeof mock>
+    getString: ReturnType<typeof mock>
+    getBoolean: ReturnType<typeof mock>
+  }
+} {
+  return {
+    deferReply: mock(() => Promise.resolve(undefined)),
+    editReply: mock(() => Promise.resolve(undefined)),
+    options: {
+      getInteger: mock((name: string) => {
+        if (name === 'skill') return opts.skill ?? 0
+        return 0
+      }),
+      getString: mock((_name: string) => null),
+      getBoolean: mock(() => false)
+    }
+  }
+}
+
+beforeEach(() => {
+  mockRoll.mockClear()
+})
+
+describe('fateCommand', () => {
+  test('titles the embed with the ladder rung', async () => {
+    const interaction = makeInteraction()
+    await fateCommand.execute(interaction as never)
+    const call = interaction.editReply.mock.calls[0]?.[0] as {
+      embeds: { toJSON: () => APIEmbed }[]
+    }
+    const embedJson = call.embeds[0]!.toJSON()
+    expect(embedJson.title).toBe('Great')
+  })
+
+  test('renders the four Fate dice symbols', async () => {
+    const interaction = makeInteraction()
+    await fateCommand.execute(interaction as never)
+    const call = interaction.editReply.mock.calls[0]?.[0] as {
+      embeds: { toJSON: () => APIEmbed }[]
+    }
+    const embedJson = call.embeds[0]!.toJSON() as { fields?: { name: string; value: string }[] }
+    const diceField = (embedJson.fields ?? []).find(f => f.name === 'Fate Dice (4dF)')
+    expect(diceField).toBeDefined()
+    expect(diceField!.value).toBe('+  +  ▢  +')
+  })
+
+  test('non-zero skill adds a skill field', async () => {
+    const interaction = makeInteraction({ skill: 3 })
+    await fateCommand.execute(interaction as never)
+    const call = interaction.editReply.mock.calls[0]?.[0] as {
+      embeds: { toJSON: () => APIEmbed }[]
+    }
+    const embedJson = call.embeds[0]!.toJSON() as { fields?: { name: string; value: string }[] }
+    const skillField = (embedJson.fields ?? []).find(f => f.name === 'Skill')
+    expect(skillField).toBeDefined()
+    expect(skillField!.value).toBe('+3')
+  })
+
+  test('zero skill omits the skill field', async () => {
+    const interaction = makeInteraction({ skill: 0 })
+    await fateCommand.execute(interaction as never)
+    const call = interaction.editReply.mock.calls[0]?.[0] as {
+      embeds: { toJSON: () => APIEmbed }[]
+    }
+    const embedJson = call.embeds[0]!.toJSON() as { fields?: { name: string }[] }
+    const fieldNames = (embedJson.fields ?? []).map(f => f.name)
+    expect(fieldNames).not.toContain('Skill')
+  })
+
+  test('clamps an out-of-range skill to the ladder bounds', async () => {
+    const interaction = makeInteraction({ skill: 99 })
+    await fateCommand.execute(interaction as never)
+    expect(mockRoll).toHaveBeenCalledWith({ modifier: 5 })
+  })
+
+  test('error path: roll throws, replies with error embed', async () => {
+    mockRoll.mockImplementationOnce(() => {
+      throw new Error('Test error')
+    })
+    const interaction = makeInteraction({ skill: 1 })
+    await fateCommand.execute(interaction as never)
+    const call = interaction.editReply.mock.calls[0]?.[0] as {
+      embeds: { toJSON: () => APIEmbed }[]
+    }
+    const embedJson = call.embeds[0]!.toJSON()
+    expect(embedJson.title).toBe('Error')
+  })
+})

--- a/apps/discord-bot/__tests__/commands/index.test.ts
+++ b/apps/discord-bot/__tests__/commands/index.test.ts
@@ -24,6 +24,7 @@ void mock.module('@randsum/roller/validate', () => ({
 
 void mock.module('@randsum/games/blades', () => ({ roll: () => ({ total: 1 }) }))
 void mock.module('@randsum/games/daggerheart', () => ({ roll: () => ({ total: 1 }) }))
+void mock.module('@randsum/games/fate', () => ({ roll: () => ({ total: 1 }) }))
 void mock.module('@randsum/games/fifth', () => ({ roll: () => ({ total: 1 }) }))
 void mock.module('@randsum/games/pbta', () => ({ roll: () => ({ total: 1 }) }))
 void mock.module('@randsum/games/root-rpg', () => ({ roll: () => ({ total: 1 }) }))
@@ -39,9 +40,9 @@ void mock.module('../../src/utils/rollButton.js', () => ({
 const { commands } = await import('../../src/commands/index.js')
 
 describe('commands barrel', () => {
-  test('exports an array of 9 commands', () => {
+  test('exports an array of 10 commands', () => {
     expect(Array.isArray(commands)).toBe(true)
-    expect(commands).toHaveLength(9)
+    expect(commands).toHaveLength(10)
   })
 
   test('each command has data and execute properties', () => {

--- a/apps/discord-bot/src/commands/fate.ts
+++ b/apps/discord-bot/src/commands/fate.ts
@@ -1,0 +1,97 @@
+import { EmbedBuilder, SlashCommandBuilder } from '../utils/discord.js'
+import { roll } from '@randsum/games/fate'
+import type { FateRollResult } from '@randsum/games/fate'
+import { embedFooterDetails } from '../utils/constants.js'
+import { deferReplyHonoringHidden } from '../utils/ephemeral.js'
+import { replyWithError } from '../utils/replyWithError.js'
+import type { Command } from '../types.js'
+
+const SKILL_MIN = -2
+const SKILL_MAX = 5
+
+// Keyed by the exported FateRollResult union so the ladder-to-colour map stays
+// exhaustive: renaming the result strings (e.g. to snake_case) surfaces here as
+// a type error rather than a silent miss.
+const ladderColors: Record<FateRollResult, number> = {
+  Legendary: 0xffd700,
+  Epic: 0xffd700,
+  Fantastic: 0x2ecc71,
+  Superb: 0x2ecc71,
+  Great: 0x2ecc71,
+  Good: 0x3498db,
+  Fair: 0x3498db,
+  Average: 0x95a5a6,
+  Mediocre: 0x95a5a6,
+  Poor: 0xe67e22,
+  Terrible: 0xe74c3c
+}
+
+function fateDieSymbol(die: number): string {
+  if (die > 0) return '+'
+  if (die < 0) return '−'
+  return '▢'
+}
+
+function buildFateEmbed(skill: number): EmbedBuilder {
+  const result = roll({ modifier: skill })
+  const dice = result.rolls[0]?.initialRolls ?? []
+  const symbols = dice.map(fateDieSymbol).join('  ')
+
+  const embed = new EmbedBuilder()
+    .setColor(ladderColors[result.result])
+    .setTitle(result.result)
+    .setDescription(`Total: ${result.total}`)
+    .setFooter(embedFooterDetails)
+
+  embed.addFields({ name: 'Fate Dice (4dF)', value: symbols || 'None', inline: true })
+
+  if (skill !== 0) {
+    embed.addFields({
+      name: 'Skill',
+      value: skill > 0 ? `+${skill}` : String(skill),
+      inline: true
+    })
+  }
+
+  embed.addFields({ name: 'Total', value: String(result.total), inline: true })
+
+  return embed
+}
+
+export const fateCommand: Command = {
+  data: new SlashCommandBuilder()
+    .setName('fate')
+    .setDescription('Roll 4dF + skill against the Fate ladder (Fate Core)')
+    .addIntegerOption(option =>
+      option
+        .setName('skill')
+        .setDescription('Skill rating on the Fate ladder (-2 to +5)')
+        .setRequired(false)
+        .setMinValue(SKILL_MIN)
+        .setMaxValue(SKILL_MAX)
+    )
+    .addBooleanOption(option =>
+      option
+        .setName('hidden')
+        .setDescription('Make the result visible only to you')
+        .setRequired(false)
+    ),
+
+  async execute(interaction) {
+    const rawSkill = interaction.options.getInteger('skill') ?? 0
+    const skill = Math.max(SKILL_MIN, Math.min(SKILL_MAX, rawSkill))
+
+    await deferReplyHonoringHidden(interaction)
+
+    try {
+      const embed = buildFateEmbed(skill)
+      await interaction.editReply({ embeds: [embed] })
+    } catch (e) {
+      await replyWithError(
+        interaction,
+        'Error',
+        e instanceof Error ? e.message : 'An unknown error occurred'
+      )
+    }
+  }
+}

--- a/apps/discord-bot/src/commands/index.ts
+++ b/apps/discord-bot/src/commands/index.ts
@@ -1,6 +1,7 @@
 import type { Command } from '../types.js'
 import { bladesCommand } from './blades.js'
 import { dhCommand } from './dh.js'
+import { fateCommand } from './fate.js'
 import { fifthCommand } from './fifth.js'
 import { helpCommand } from './help.js'
 import { notationCommand } from './notation.js'
@@ -12,6 +13,7 @@ import { suCommand } from './su.js'
 export const commands: readonly Command[] = [
   bladesCommand,
   dhCommand,
+  fateCommand,
   fifthCommand,
   helpCommand,
   notationCommand,

--- a/apps/site/astro.config.mjs
+++ b/apps/site/astro.config.mjs
@@ -156,6 +156,7 @@ export default defineConfig({
                   { label: 'Blades in the Dark', slug: 'games/blades' },
                   { label: 'D&D 5e', slug: 'games/fifth' },
                   { label: 'Daggerheart', slug: 'games/daggerheart' },
+                  { label: 'Fate Core', slug: 'games/fate' },
                   { label: 'Powered by the Apocalypse', slug: 'games/pbta' },
                   { label: 'Root RPG', slug: 'games/root-rpg' },
                   { label: 'Salvage Union', slug: 'games/salvageunion' }

--- a/apps/site/src/content/docs/games/fate.mdx
+++ b/apps/site/src/content/docs/games/fate.mdx
@@ -1,0 +1,149 @@
+---
+title: Fate Core
+description: TypeScript package for Fate Core dice. Rolls 4dF, adds a skill rating, and resolves the result against the Fate ladder from Terrible up to Legendary.
+head:
+  - tag: script
+    attrs:
+      type: application/ld+json
+    content: |
+      {
+        "@context": "https://schema.org",
+        "@type": "SoftwareApplication",
+        "name": "@randsum/games/fate",
+        "applicationCategory": "DeveloperApplication",
+        "programmingLanguage": "TypeScript",
+        "version": "3.0.1",
+        "description": "TypeScript dice rolling package for Fate Core. Rolls 4dF plus a skill rating and resolves the result against the Fate ladder.",
+        "offers": { "@type": "Offer", "price": "0", "priceCurrency": "USD" },
+        "downloadUrl": "https://www.npmjs.com/package/@randsum/games",
+        "codeRepository": "https://github.com/RANDSUM/randsum/tree/main/packages/games",
+        "keywords": "Fate Core, Fudge, 4dF, Fate ladder, dice, TypeScript, tabletop RPG"
+      }
+---
+
+import { Tabs, TabItem, LinkCard } from '@astrojs/starlight/components'
+import CodeExample from '../../../components/live-repl/CodeExample.astro'
+
+The `@randsum/games/fate` subpath provides mechanics for [Fate Core](https://www.evilhat.com/home/fate-core/), a tabletop RPG that rolls four Fate dice (`4dF`), adds a skill rating, and reads the total off the Fate ladder.
+
+<LinkCard title="Official Site" href="https://www.evilhat.com/home/fate-core/" description="Fate Core by Evil Hat" />
+
+## Installation
+
+<Tabs>
+  <TabItem label="bun">
+    <CodeExample lang="bash" code={`bun add @randsum/games`} />
+  </TabItem>
+  <TabItem label="npm">
+    <CodeExample lang="bash" code={`npm install @randsum/games`} />
+  </TabItem>
+</Tabs>
+
+## Usage
+
+<CodeExample code={`import { roll } from '@randsum/games/fate'
+
+// Roll 4dF with no skill modifier
+const { result, total } = roll()
+console.log(total)  // -4 to +4
+console.log(result) // e.g. 'Mediocre'`} />
+
+<CodeExample code={`import { roll } from '@randsum/games/fate'
+
+// Add a skill rating (a rung on the Fate ladder, -2 to +5)
+roll(3)             // scalar overload: skill of +3
+roll({ modifier: 3 }) // object overload: the same roll`} />
+
+<CodeExample code={`import { roll } from '@randsum/games/fate'
+
+const { result } = roll({ modifier: 4 })
+
+switch (result) {
+  case 'Legendary':
+  case 'Epic':
+  case 'Fantastic':
+    // A standout success
+    break
+  case 'Superb':
+  case 'Great':
+  case 'Good':
+    // A solid success
+    break
+  default:
+    // Fair and below
+    break
+}`} />
+
+## API
+
+### `roll(modifier?: number)` / `roll(input?: { modifier?: number })`
+
+**Input:**
+
+| Parameter | Type | Description |
+|---|---|---|
+| `modifier` | `number` (optional) | Skill rating — a rung on the Fate ladder (`-2` to `+5`), added to the 4dF total |
+
+**Returns:** `GameRollResult` with:
+
+| Property | Type | Description |
+|---|---|---|
+| `result` | `FateRollResult` | The ladder rung the total lands on |
+| `total` | `number` | The 4dF total plus the skill modifier |
+| `rolls` | `RollRecord[]` | Raw dice data from the core roller (each Fate die is `-1`, `0`, or `+1`) |
+
+## The Fate ladder
+
+Fate dice are six-sided dice with two `+` faces, two blank faces, and two `−` faces, read as `+1`, `0`, and `−1`. Four of them (`4dF`) sum to a total between `-4` and `+4`. Add your skill rating and read the result off the ladder:
+
+| Total | Rung |
+|---|---|
+| +8 or more | `Legendary` |
+| +7 | `Epic` |
+| +6 | `Fantastic` |
+| +5 | `Superb` |
+| +4 | `Great` |
+| +3 | `Good` |
+| +2 | `Fair` |
+| +1 | `Average` |
+| 0 | `Mediocre` |
+| -1 | `Poor` |
+| -2 or less | `Terrible` |
+
+The open-ended `Legendary` and `Terrible` rungs absorb any total beyond the ends of the ladder.
+
+## Error handling
+
+Game `roll()` can throw two types of errors:
+
+- **`ValidationError`** (from `@randsum/roller`) — the skill modifier is out of range (`-2` to `+5`) or not finite
+- **`SchemaError`** (from `@randsum/games/fate`) — game-specific issues like an unmatched ladder rung
+
+<CodeExample code={`import { roll, SchemaError } from '@randsum/games/fate'
+import { ValidationError } from '@randsum/roller'
+
+try {
+  roll(99)
+} catch (error) {
+  if (error instanceof ValidationError) {
+    // Out-of-range skill rating (must be -2 to +5)
+    console.log(error.code)    // 'VALIDATION_ERROR'
+  } else if (error instanceof SchemaError) {
+    // Game-specific error
+    console.log(error.code)    // 'NO_TABLE_MATCH'
+  }
+}`} />
+
+## Types
+
+<CodeExample code={`import type { FateRollResult, GameRollResult, RollRecord } from '@randsum/games/fate'
+import { SchemaError } from '@randsum/games/fate'`} />
+
+## Schema
+
+This game is powered by a `.randsum.json` spec that defines the dice pool, the ladder outcomes, and validation rules. The TypeScript code is generated from this spec at build time. See [Schema Overview](/games/schema/overview/) for how game specs work.
+
+## Links
+
+- [npm package](https://www.npmjs.com/package/@randsum/games)
+- [Source code](https://github.com/RANDSUM/randsum/tree/main/packages/games)

--- a/apps/site/src/content/docs/games/schema/contributing-a-game.mdx
+++ b/apps/site/src/content/docs/games/schema/contributing-a-game.mdx
@@ -173,7 +173,7 @@ Adapt these templates to your game's inputs and outcomes. See existing test file
 
 - **Start simple.** Get a basic spec working before adding inputs, conditional pools, or complex outcome trees. You can iterate in follow-up PRs.
 - **Use `loadSpec` for rapid iteration.** While developing your spec, use [`loadSpec()`](/games/schema/using-loadspec/) to test it without running codegen on every change.
-- **Check existing specs.** The six built-in game specs in `packages/games/` cover a range of mechanics — table-based with dynamic lookup (salvageunion), advantage/disadvantage (fifth), pool-based (blades), dual-pool (daggerheart), and 2d6+stat (pbta). The [Salvage Union spec](https://github.com/RANDSUM/randsum/blob/main/packages/games/salvageunion.randsum.json) is the richest example, with multiple roll tables and range-based outcomes. Find the one closest to your game and use it as a starting point.
+- **Check existing specs.** The seven built-in game specs in `packages/games/` cover a range of mechanics — table-based with dynamic lookup (salvageunion), advantage/disadvantage (fifth), pool-based (blades), dual-pool (daggerheart), and 2d6+stat (pbta). The [Salvage Union spec](https://github.com/RANDSUM/randsum/blob/main/packages/games/salvageunion.randsum.json) is the richest example, with multiple roll tables and range-based outcomes. Find the one closest to your game and use it as a starting point.
 - **Table ranges must cover all possible values.** If your die produces 1-6, your outcome table must account for every value from 1 to 6. Gaps cause `SchemaError` with code `'NO_TABLE_MATCH'` at runtime.
 
 ## Learn more

--- a/apps/site/src/content/docs/tools/claude-code-plugin.mdx
+++ b/apps/site/src/content/docs/tools/claude-code-plugin.mdx
@@ -15,7 +15,7 @@ RANDSUM provides a **Claude Code plugin** with three skills that give AI agents 
 
 <CardGrid>
   <Card title="Dice Rolling" icon="rocket">
-    Roll dice, interpret results, and answer questions about RANDSUM notation and supported game systems. Covers all 19+ modifiers and 6 game systems.
+    Roll dice, interpret results, and answer questions about RANDSUM notation and supported game systems. Covers all 19+ modifiers and 7 game systems.
   </Card>
   <Card title="Dice Probability" icon="bars">
     Analyze probability distributions, expected values, and outcome comparisons. Compare strategies like "advantage vs. flat +2" with exact math or Monte Carlo simulation.
@@ -92,7 +92,7 @@ Paste skill content directly into any LLM conversation. Each skill is self-conta
 
 ### Dice Rolling
 
-The core skill. Teaches an agent RANDSUM dice notation — a compact syntax for any roll — and how to interpret results for six supported game systems: D&D 5e, Blades in the Dark, Daggerheart, PbtA, Root RPG, and Salvage Union.
+The core skill. Teaches an agent RANDSUM dice notation — a compact syntax for any roll — and how to interpret results for seven supported game systems: D&D 5e, Blades in the Dark, Daggerheart, Fate Core, PbtA, Root RPG, and Salvage Union.
 
 **What the agent learns:**
 - All RANDSUM notation syntax (`4d6L`, `2d20H+5`, `3d6!`, `d%`, `4dF`, etc.)

--- a/apps/site/src/utils/packageData.ts
+++ b/apps/site/src/utils/packageData.ts
@@ -1,3 +1,6 @@
+import rollerPkg from '../../../../packages/roller/package.json'
+import gamesPkg from '../../../../packages/games/package.json'
+
 interface PackageInfo {
   id: string
   name: string
@@ -18,7 +21,7 @@ export const corePackages: PackageInfo[] = [
     description: 'Zero-dependency dice engine with built-in notation parsing and validation.',
     npmPackage: '@randsum/roller',
     sourceUrl: 'https://github.com/RANDSUM/randsum/tree/main/packages/roller',
-    version: '1.3.0',
+    version: rollerPkg.version,
     category: 'core',
     color: '#f8fafc' // white (slate-50) — uses --tool-roller CSS var which adapts dark/light
   },
@@ -26,10 +29,10 @@ export const corePackages: PackageInfo[] = [
     id: 'games',
     name: 'games',
     displayName: 'Games',
-    description: 'Pre-built dice resolvers for popular tabletop RPGs. One package, six systems.',
+    description: 'Pre-built dice resolvers for popular tabletop RPGs. One package, seven systems.',
     npmPackage: '@randsum/games',
     sourceUrl: 'https://github.com/RANDSUM/randsum/tree/main/packages/games',
-    version: '1.3.0',
+    version: gamesPkg.version,
     category: 'core',
     color: '#a855f7' // purple accent
   }
@@ -44,7 +47,7 @@ export const gamePackages: PackageInfo[] = [
       'Roll action dice. Resolve critical, success, partial, or failure for Blades in the Dark.',
     npmPackage: '@randsum/games/blades',
     sourceUrl: 'https://github.com/RANDSUM/randsum/tree/main/packages/games',
-    version: '1.3.0',
+    version: gamesPkg.version,
     category: 'game',
     color: '#64748b' // slate-500 — noir, shadowy
   },
@@ -56,9 +59,21 @@ export const gamePackages: PackageInfo[] = [
       'Roll hope and fear dice, see which dominates, detect critical hope for Daggerheart.',
     npmPackage: '@randsum/games/daggerheart',
     sourceUrl: 'https://github.com/RANDSUM/randsum/tree/main/packages/games',
-    version: '1.3.0',
+    version: gamesPkg.version,
     category: 'game',
     color: '#eab308' // yellow-500 — gold
+  },
+  {
+    id: 'fate',
+    name: 'fate',
+    displayName: 'Fate Core',
+    description:
+      'Roll 4dF + skill against the Fate ladder. Resolve Terrible up to Legendary for Fate Core.',
+    npmPackage: '@randsum/games/fate',
+    sourceUrl: 'https://github.com/RANDSUM/randsum/tree/main/packages/games',
+    version: gamesPkg.version,
+    category: 'game',
+    color: '#0ea5e9' // sky-500 — Fate blue
   },
   {
     id: 'fifth',
@@ -67,7 +82,7 @@ export const gamePackages: PackageInfo[] = [
     description: 'd20 roll resolution for D&D 5e.',
     npmPackage: '@randsum/games/fifth',
     sourceUrl: 'https://github.com/RANDSUM/randsum/tree/main/packages/games',
-    version: '1.3.0',
+    version: gamesPkg.version,
     category: 'game',
     color: '#dc2626' // red
   },
@@ -78,7 +93,7 @@ export const gamePackages: PackageInfo[] = [
     description: 'Roll 2d6+bonus. Strong hit, weak hit, or miss for Root: The RPG.',
     npmPackage: '@randsum/games/root-rpg',
     sourceUrl: 'https://github.com/RANDSUM/randsum/tree/main/packages/games',
-    version: '1.3.0',
+    version: gamesPkg.version,
     category: 'game',
     color: '#22c55e' // green
   },
@@ -89,7 +104,7 @@ export const gamePackages: PackageInfo[] = [
     description: 'd20 table lookups for Salvage Union.',
     npmPackage: '@randsum/games/salvageunion',
     sourceUrl: 'https://github.com/RANDSUM/randsum/tree/main/packages/games',
-    version: '1.3.0',
+    version: gamesPkg.version,
     category: 'game',
     color: '#f59e0b' // amber — industrial/salvage aesthetic
   },
@@ -101,7 +116,7 @@ export const gamePackages: PackageInfo[] = [
       'Roll 2d6+stat. Miss, weak hit, or strong hit for any Powered by the Apocalypse game.',
     npmPackage: '@randsum/games/pbta',
     sourceUrl: 'https://github.com/RANDSUM/randsum/tree/main/packages/games',
-    version: '1.3.0',
+    version: gamesPkg.version,
     category: 'game',
     color: '#6b7280' // grey
   }


### PR DESCRIPTION
## Summary

The `@randsum/games/fate` subpath (Fate Core: 4dF + skill resolved against the Fate ladder, Legendary down to Terrible) shipped to npm with **zero user-facing surface** — no Discord command, no docs page, no landing card. This PR closes that gap.

### Discord bot
- **New `/fate` command** (`apps/discord-bot/src/commands/fate.ts`) modeled precisely on the sibling game commands: a `skill` integer option (clamped to the ladder's -2..+5 so out-of-range input never throws), plus the standard `hidden` option and `deferReplyHonoringHidden` / `replyWithError` flow. The embed renders the four Fate dice as `+ / ▢ / −` symbols and titles itself with the ladder rung.
- Colours are keyed off the exported `FateRollResult` union via a `Record<FateRollResult, number>`, so the planned snake_case rename of result strings will surface as a **type error** here rather than a silent colour miss.
- Registered in the commands barrel (`src/commands/index.ts`); new `__tests__/commands/fate.test.ts` mirrors the pbta/dh test shape. Updated `index.test.ts` (barrel count 9 → 10, added the `@randsum/games/fate` mock) — a necessary consequence of registering the command.

### Docs site
- **New `apps/site/src/content/docs/games/fate.mdx`** following the structure of the other game pages (installation, usage, API, ladder table, error handling, types, schema), plus a **Fate Core** entry in the Game Systems sidebar (`astro.config.mjs`) in alphabetical position.
- `src/utils/packageData.ts`: added the `fate` landing card **and** stopped hardcoding versions — roller/games versions are now imported from the workspace `package.json` files (`import … with resolveJsonModule`), so the landing cards can no longer drift. They were pinned at `1.3.0`/`1.3.0` while the real published versions are `2.0.0`/`3.0.1`; the cards now read the true versions automatically.

### Prose / correctness fixes
- "six popular game systems" / "6 game systems" / "six built-in game specs" / "six systems" corrected to **seven** across `claude-code-plugin.mdx`, `games/schema/contributing-a-game.mdx`, `packageData.ts`, and `LISTING.md` (with Fate Core added to the bot's supported-systems list, commands table, tags, and command count).
- Fixed the invalid notation example `4d6!>5` → `4d6!{>5}` in `LISTING.md` (conditional explode requires the `!{condition}` brace form per the notation spec).

## Verification
- `bun run --filter @randsum/discord-bot test` → **72 pass, 0 fail** (13 files)
- `bun run --filter @randsum/discord-bot lint` → clean
- `bun run --filter @randsum/discord-bot typecheck` → clean
- `bun run build` (roller + games first) then `bun run --filter @randsum/site check` → build, `astro check` (0 errors), prettier, eslint, and 33 tests all pass
- Confirmed the dynamic versions resolve: `roller 2.0.0 | games 3.0.1 | fate 3.0.1`
- Pre-commit and pre-push hooks (build, all-package lint/typecheck, tests, audit, knip, arch) ran and passed.

Note: an initial commit attempt hit a transient "type could not be resolved" lint error in the unrelated `@randsum/rdn` package caused by the hook's own priority-1 `bun install` step relinking `node_modules` concurrently with the parallel typed-lint. `@randsum/rdn` is not touched by this diff and its lint passes deterministically (exit 0) both with the changes applied standalone and with them stashed; the commit/push succeeded on retry with stable `node_modules`.

From the 2026-07-07 monorepo deep-dive audit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019DMVgLnWbodhurNKcGM1oz