### PR TITLE
fix(discord-bot): remove dead embed images, fix /fifth tie display, command consistency, build/deploy fixes

### DIFF
--- a/apps/discord-bot/__tests__/commands/fifth.test.ts
+++ b/apps/discord-bot/__tests__/commands/fifth.test.ts
@@ -113,6 +113,59 @@ describe('fifthCommand', () => {
     expect(embedJson.title).toBe('Natural 1! D&D 5e Roll: 1')
   })
 
+  test('advantage tie: kept die bold, dropped die struck (not both bold)', async () => {
+    // Both d20s show 4. The roller keeps one (rolls: [4]); the display must
+    // bold exactly one die and strike the other, never bold both.
+    mockRoll.mockImplementationOnce(() => ({
+      total: 4,
+      result: 4,
+      rolls: [{ initialRolls: [4, 4], rolls: [4], modifierLogs: [] }],
+      details: { criticals: undefined }
+    }))
+    const interaction = makeInteraction(0, 'Advantage')
+    await fifthCommand.execute(interaction as never)
+    const call = interaction.editReply.mock.calls[0]?.[0] as {
+      embeds: { toJSON: () => APIEmbed }[]
+    }
+    const embedJson = call.embeds[0]!.toJSON()
+    const diceField = embedJson.fields?.find(f => f.name === 'Dice Rolled (2d20)')
+    expect(diceField?.value).toBe('**4**, ~~4~~')
+  })
+
+  test('disadvantage tie: kept die bold, dropped die struck (not both bold)', async () => {
+    mockRoll.mockImplementationOnce(() => ({
+      total: 17,
+      result: 17,
+      rolls: [{ initialRolls: [17, 17], rolls: [17], modifierLogs: [] }],
+      details: { criticals: undefined }
+    }))
+    const interaction = makeInteraction(0, 'Disadvantage')
+    await fifthCommand.execute(interaction as never)
+    const call = interaction.editReply.mock.calls[0]?.[0] as {
+      embeds: { toJSON: () => APIEmbed }[]
+    }
+    const embedJson = call.embeds[0]!.toJSON()
+    const diceField = embedJson.fields?.find(f => f.name === 'Dice Rolled (2d20)')
+    expect(diceField?.value).toBe('**17**, ~~17~~')
+  })
+
+  test('advantage non-tie: higher kept bold, lower struck', async () => {
+    mockRoll.mockImplementationOnce(() => ({
+      total: 18,
+      result: 18,
+      rolls: [{ initialRolls: [18, 5], rolls: [18], modifierLogs: [] }],
+      details: { criticals: undefined }
+    }))
+    const interaction = makeInteraction(0, 'Advantage')
+    await fifthCommand.execute(interaction as never)
+    const call = interaction.editReply.mock.calls[0]?.[0] as {
+      embeds: { toJSON: () => APIEmbed }[]
+    }
+    const embedJson = call.embeds[0]!.toJSON()
+    const diceField = embedJson.fields?.find(f => f.name === 'Dice Rolled (2d20)')
+    expect(diceField?.value).toBe('**18**, ~~5~~')
+  })
+
   test('error path: roll throws, replies with error embed', async () => {
     mockRoll.mockImplementationOnce(() => {
       throw new Error('Test error')

--- a/apps/discord-bot/__tests__/commands/help.test.ts
+++ b/apps/discord-bot/__tests__/commands/help.test.ts
@@ -1,51 +1,32 @@
 import { describe, expect, mock, test } from 'bun:test'
 import type { APIEmbed } from 'discord.js'
 
-void mock.module('@randsum/roller', () => ({
-  roll: () => ({ total: 1, result: ['1'], rolls: [] }),
-  notation: () => ({}),
-  isDiceNotation: () => true,
-  validateNotation: () => ({}),
-  validateFinite: () => true,
-  validateRange: () => true,
-  suggestNotationFix: () => undefined
-}))
-
-void mock.module('@randsum/roller/roll', () => ({
-  roll: () => ({ total: 1, result: ['1'], rolls: [] })
-}))
-
-void mock.module('@randsum/roller/validate', () => ({
-  notation: () => ({}),
-  isDiceNotation: () => true,
-  validateNotation: () => ({}),
-  validateFinite: () => true,
-  validateRange: () => true
-}))
-
-void mock.module('@randsum/games/blades', () => ({ roll: () => ({ total: 1 }) }))
-void mock.module('@randsum/games/daggerheart', () => ({ roll: () => ({ total: 1 }) }))
-void mock.module('@randsum/games/fifth', () => ({ roll: () => ({ total: 1 }) }))
-void mock.module('@randsum/games/pbta', () => ({ roll: () => ({ total: 1 }) }))
-void mock.module('@randsum/games/root-rpg', () => ({ roll: () => ({ total: 1 }) }))
-void mock.module('@randsum/games/salvageunion', () => ({
-  roll: () => ({ total: 1 }),
-  VALID_TABLE_NAMES: ['Core Mechanic']
-}))
-
-void mock.module('../../src/utils/rollButton.js', () => ({
-  createRollButton: mock(() => ({}))
-}))
-
 const { helpCommand } = await import('../../src/commands/help.js')
 
-function makeInteraction(): {
+interface FakeCommand {
+  data: { name: string; description: string }
+}
+
+function makeCommands(): Map<string, FakeCommand> {
+  const entries: FakeCommand[] = [
+    { data: { name: 'roll', description: 'Roll dice' } },
+    { data: { name: 'blades', description: 'Blades in the Dark' } },
+    { data: { name: 'help', description: 'List all available RANDSUM commands' } }
+  ]
+  return new Map(entries.map(cmd => [cmd.data.name, cmd]))
+}
+
+function makeInteraction(hidden = false): {
   deferReply: ReturnType<typeof mock>
   editReply: ReturnType<typeof mock>
+  options: { getBoolean: ReturnType<typeof mock> }
+  client: { commands: Map<string, FakeCommand> }
 } {
   return {
     deferReply: mock(() => Promise.resolve(undefined)),
-    editReply: mock(() => Promise.resolve(undefined))
+    editReply: mock(() => Promise.resolve(undefined)),
+    options: { getBoolean: mock(() => hidden) },
+    client: { commands: makeCommands() }
   }
 }
 
@@ -57,6 +38,12 @@ describe('helpCommand', () => {
   test('has a description', () => {
     expect(typeof helpCommand.data.description).toBe('string')
     expect(helpCommand.data.description.length).toBeGreaterThan(0)
+  })
+
+  test('exposes a hidden option', () => {
+    const json = helpCommand.data.toJSON() as { options?: { name: string }[] }
+    const optionNames = (json.options ?? []).map(o => o.name)
+    expect(optionNames).toContain('hidden')
   })
 
   test('execute: defers reply', async () => {
@@ -93,14 +80,16 @@ describe('helpCommand', () => {
     expect(embedJson.footer).toBeDefined()
   })
 
-  test('execute: embed lists commands via addFields', async () => {
+  test('execute: lists commands from the client collection, excluding help itself', async () => {
     const interaction = makeInteraction()
     await helpCommand.execute(interaction as never)
     const call = interaction.editReply.mock.calls[0]?.[0] as {
       embeds: { toJSON: () => APIEmbed }[]
     }
-    const embedJson = call.embeds[0]!.toJSON() as { fields?: unknown[] }
-    expect(embedJson.fields).toBeDefined()
-    expect((embedJson.fields ?? []).length).toBeGreaterThan(0)
+    const embedJson = call.embeds[0]!.toJSON() as { fields?: { name: string }[] }
+    const fieldNames = (embedJson.fields ?? []).map(f => f.name)
+    expect(fieldNames).toContain('/roll')
+    expect(fieldNames).toContain('/blades')
+    expect(fieldNames).not.toContain('/help')
   })
 })

--- a/apps/discord-bot/__tests__/commands/notation.test.ts
+++ b/apps/discord-bot/__tests__/commands/notation.test.ts
@@ -57,10 +57,12 @@ const { notationCommand } = await import('../../src/commands/notation.js')
 function makeInteraction(): {
   deferReply: ReturnType<typeof mock>
   editReply: ReturnType<typeof mock>
+  options: { getBoolean: ReturnType<typeof mock> }
 } {
   return {
     deferReply: mock(() => Promise.resolve(undefined)),
-    editReply: mock(() => Promise.resolve(mockMessage) as ReturnType<ReturnType<typeof mock>>)
+    editReply: mock(() => Promise.resolve(mockMessage) as ReturnType<ReturnType<typeof mock>>),
+    options: { getBoolean: mock(() => false) }
   }
 }
 

--- a/apps/discord-bot/__tests__/commands/root.test.ts
+++ b/apps/discord-bot/__tests__/commands/root.test.ts
@@ -18,7 +18,7 @@ function makeInteraction(modifier: number | null = null): {
     getInteger: ReturnType<typeof mock>
     getBoolean: ReturnType<typeof mock>
   }
-  member: { user: { username: string } }
+  user: { displayName: string }
 } {
   return {
     deferReply: mock(() => Promise.resolve(undefined)),
@@ -27,7 +27,7 @@ function makeInteraction(modifier: number | null = null): {
       getInteger: mock(() => modifier),
       getBoolean: mock(() => false)
     },
-    member: { user: { username: 'Tester' } }
+    user: { displayName: 'Tester' }
   }
 }
 

--- a/apps/discord-bot/bunup.config.ts
+++ b/apps/discord-bot/bunup.config.ts
@@ -3,8 +3,8 @@ import { defineConfig } from 'bunup'
 export default defineConfig({
   entry: ['src/index.ts'],
   format: ['esm'],
-  dts: true,
-  minify: true,
+  dts: false,
+  minify: false,
   sourcemap: 'external',
   target: 'node',
   clean: true

--- a/apps/discord-bot/src/commands/blades.ts
+++ b/apps/discord-bot/src/commands/blades.ts
@@ -1,6 +1,6 @@
 import { EmbedBuilder, SlashCommandBuilder } from '../utils/discord.js'
 import { roll } from '@randsum/games/blades'
-import { D6_IMAGES, embedFooterDetails } from '../utils/constants.js'
+import { embedFooterDetails } from '../utils/constants.js'
 import { deferReplyHonoringHidden } from '../utils/ephemeral.js'
 import { replyWithError } from '../utils/replyWithError.js'
 import type { Command } from '../types.js'
@@ -15,36 +15,31 @@ function buildBladesEmbed(dice: number): EmbedBuilder {
     critical: {
       color: 0xffd700,
       resultTitle: 'Critical Success!',
-      resultDescription: 'Things go better than expected',
-      thumbnail: D6_IMAGES.double6
+      resultDescription: 'Things go better than expected'
     },
     success: {
       color: 0x00ff00,
       resultTitle: 'Success!',
-      resultDescription: 'You succeed at your goal',
-      thumbnail: D6_IMAGES[6]
+      resultDescription: 'You succeed at your goal'
     },
     partial: {
       color: 0xffff00,
       resultTitle: 'Partial Success',
-      resultDescription: 'You succeed, but with a consequence',
-      thumbnail: D6_IMAGES[highestDie as keyof typeof D6_IMAGES]
+      resultDescription: 'You succeed, but with a consequence'
     },
     failure: {
       color: 0xff0000,
       resultTitle: 'Failure',
-      resultDescription: "Things don't go your way",
-      thumbnail: D6_IMAGES[highestDie as keyof typeof D6_IMAGES]
+      resultDescription: "Things don't go your way"
     }
   }
 
-  const { color, resultTitle, resultDescription, thumbnail } = resultConfig[result.result]
+  const { color, resultTitle, resultDescription } = resultConfig[result.result]
 
   const embed = new EmbedBuilder()
     .setColor(color)
     .setTitle(resultTitle)
     .setDescription(resultDescription)
-    .setThumbnail(thumbnail)
     .setFooter(embedFooterDetails)
 
   embed.addFields({

--- a/apps/discord-bot/src/commands/fifth.ts
+++ b/apps/discord-bot/src/commands/fifth.ts
@@ -10,6 +10,27 @@ interface FifthParams {
   readonly rollingWith: 'Advantage' | 'Disadvantage' | null
 }
 
+/**
+ * Renders each initial d20 with the kept die(s) bold and the dropped die(s)
+ * struck through. Kept values are matched against the roller's post-modifier
+ * `rolls` (the dice it actually kept) and consumed one-by-one, so a tie — where
+ * both d20s show the same face — still renders exactly one bold and one struck
+ * die rather than bolding both.
+ */
+function markKeptRolls(initialRolls: number[], keptRolls: number[]): string {
+  const remaining = [...keptRolls]
+  return initialRolls
+    .map(r => {
+      const idx = remaining.indexOf(r)
+      if (idx !== -1) {
+        remaining.splice(idx, 1)
+        return `**${r}**`
+      }
+      return `~~${r}~~`
+    })
+    .join(', ')
+}
+
 function buildFifthEmbed({ modifier, rollingWith }: FifthParams): EmbedBuilder {
   const result = roll({
     modifier,
@@ -18,6 +39,7 @@ function buildFifthEmbed({ modifier, rollingWith }: FifthParams): EmbedBuilder {
   })
 
   const initialRolls = result.rolls[0]?.initialRolls ?? []
+  const keptRolls = result.rolls[0]?.rolls ?? []
   const criticals = result.details.criticals
   const isNat20 = criticals?.isNatural20 === true
   const isNat1 = criticals?.isNatural1 === true
@@ -33,15 +55,7 @@ function buildFifthEmbed({ modifier, rollingWith }: FifthParams): EmbedBuilder {
 
   const rollsText =
     rollingWith && initialRolls.length > 1
-      ? initialRolls
-          .map(r => {
-            const kept =
-              rollingWith === 'Advantage'
-                ? r === Math.max(...initialRolls)
-                : r === Math.min(...initialRolls)
-            return kept ? `**${r}**` : `~~${r}~~`
-          })
-          .join(', ')
+      ? markKeptRolls(initialRolls, keptRolls)
       : initialRolls.join(', ')
 
   embed.addFields({

--- a/apps/discord-bot/src/commands/help.ts
+++ b/apps/discord-bot/src/commands/help.ts
@@ -1,39 +1,31 @@
 import { EmbedBuilder, SlashCommandBuilder } from '../utils/discord.js'
+import type { Client, Collection } from '../utils/discord.js'
 import { embedFooterDetails } from '../utils/constants.js'
+import { deferReplyHonoringHidden } from '../utils/ephemeral.js'
 import type { Command } from '../types.js'
-import { bladesCommand } from './blades.js'
-import { dhCommand } from './dh.js'
-import { fifthCommand } from './fifth.js'
-import { notationCommand } from './notation.js'
-import { pbtaCommand } from './pbta.js'
-import { rollCommand } from './roll.js'
-import { rootCommand } from './root.js'
-import { suCommand } from './su.js'
-
-const listedCommands: readonly Command[] = [
-  rollCommand,
-  notationCommand,
-  bladesCommand,
-  dhCommand,
-  fifthCommand,
-  pbtaCommand,
-  rootCommand,
-  suCommand
-]
 
 export const helpCommand: Command = {
   data: new SlashCommandBuilder()
     .setName('help')
-    .setDescription('List all available RANDSUM commands'),
+    .setDescription('List all available RANDSUM commands')
+    .addBooleanOption(option =>
+      option
+        .setName('hidden')
+        .setDescription('Make the result visible only to you')
+        .setRequired(false)
+    ),
 
   async execute(interaction) {
-    await interaction.deferReply()
+    await deferReplyHonoringHidden(interaction)
 
-    const fields = listedCommands.map(cmd => ({
-      name: `/${cmd.data.name}`,
-      value: cmd.data.description,
-      inline: false
-    }))
+    const client = interaction.client as Client & { commands: Collection<string, Command> }
+    const fields = [...client.commands.values()]
+      .filter(cmd => cmd.data.name !== 'help')
+      .map(cmd => ({
+        name: `/${cmd.data.name}`,
+        value: cmd.data.description,
+        inline: false
+      }))
 
     const embed = new EmbedBuilder()
       .setColor('#FFD700')

--- a/apps/discord-bot/src/commands/notation.ts
+++ b/apps/discord-bot/src/commands/notation.ts
@@ -9,6 +9,7 @@ import type { StringSelectMenuInteraction } from '../utils/discord.js'
 import { NOTATION_DOCS } from '@randsum/roller/docs'
 import type { NotationDoc } from '@randsum/roller/docs'
 import { embedFooterDetails } from '../utils/constants.js'
+import { deferReplyHonoringHidden } from '../utils/ephemeral.js'
 import { replyWithError } from '../utils/replyWithError.js'
 import { captureException } from '../utils/errorTracker.js'
 import type { Command } from '../types.js'
@@ -50,10 +51,16 @@ function buildCategoryEmbed(category: string, entries: NotationDoc[]): EmbedBuil
 export const notationCommand: Command = {
   data: new SlashCommandBuilder()
     .setName('notation')
-    .setDescription('RANDSUM Dice Notation Reference'),
+    .setDescription('RANDSUM Dice Notation Reference')
+    .addBooleanOption(option =>
+      option
+        .setName('hidden')
+        .setDescription('Make the result visible only to you')
+        .setRequired(false)
+    ),
 
   async execute(interaction) {
-    await interaction.deferReply()
+    await deferReplyHonoringHidden(interaction)
 
     try {
       const grouped = groupByCategory(NOTATION_DOCS)
@@ -74,11 +81,11 @@ export const notationCommand: Command = {
           }))
         )
 
-      const row = new ActionRowBuilder().addComponents(selectMenu)
+      const row = new ActionRowBuilder<StringSelectMenuBuilder>().addComponents(selectMenu)
 
       const message = await interaction.editReply({
         embeds: [embed],
-        components: [row as never]
+        components: [row]
       })
 
       const collector = message.createMessageComponentCollector({
@@ -106,11 +113,13 @@ export const notationCommand: Command = {
                 }))
               )
 
-            const updatedRow = new ActionRowBuilder().addComponents(updatedMenu)
+            const updatedRow = new ActionRowBuilder<StringSelectMenuBuilder>().addComponents(
+              updatedMenu
+            )
 
             await selectInteraction.update({
               embeds: [categoryEmbed],
-              components: [updatedRow as never]
+              components: [updatedRow]
             })
           } catch (error) {
             captureException(error, {
@@ -137,10 +146,12 @@ export const notationCommand: Command = {
               )
               .setDisabled(true)
 
-            const disabledRow = new ActionRowBuilder().addComponents(disabledMenu)
+            const disabledRow = new ActionRowBuilder<StringSelectMenuBuilder>().addComponents(
+              disabledMenu
+            )
 
             await message.edit({
-              components: [disabledRow as never]
+              components: [disabledRow]
             })
           } catch (error) {
             captureException(error, {

--- a/apps/discord-bot/src/commands/root.ts
+++ b/apps/discord-bot/src/commands/root.ts
@@ -5,13 +5,7 @@ import { deferReplyHonoringHidden } from '../utils/ephemeral.js'
 import { replyWithError } from '../utils/replyWithError.js'
 import type { Command } from '../types.js'
 
-const ROOT_IMAGES = {
-  'Strong Hit': 'https://files.randsum.io/root-strong-hit.png',
-  'Weak Hit': 'https://files.randsum.io/root-weak-hit.png',
-  Miss: 'https://files.randsum.io/root-miss.png'
-} as const
-
-function buildRootEmbed(modifier: number, memberNick: string): EmbedBuilder {
+function buildRootEmbed(modifier: number, displayName: string): EmbedBuilder {
   const result = roll({ bonus: modifier })
   const initialRolls = result.rolls[0]?.initialRolls ?? []
 
@@ -25,13 +19,11 @@ function buildRootEmbed(modifier: number, memberNick: string): EmbedBuilder {
   } as const
 
   const { color, resultDescription } = resultConfig[result.result]
-  const thumbnail = ROOT_IMAGES[result.result]
 
   const embed = new EmbedBuilder()
     .setColor(color)
-    .setTitle(`${memberNick} rolled a ${result.result}`)
+    .setTitle(`${displayName} rolled a ${result.result}`)
     .setDescription(resultDescription)
-    .setThumbnail(thumbnail)
     .setFooter(embedFooterDetails)
 
   embed.addFields({ name: 'Dice Rolls', value: initialRolls.join(', '), inline: true })
@@ -69,12 +61,12 @@ export const rootCommand: Command = {
 
   async execute(interaction) {
     const modifier = interaction.options.getInteger('modifier') ?? 0
-    const memberNick = interaction.member?.user.username ?? 'Unknown'
+    const displayName = interaction.user.displayName
 
     await deferReplyHonoringHidden(interaction)
 
     try {
-      const embed = buildRootEmbed(modifier, memberNick)
+      const embed = buildRootEmbed(modifier, displayName)
       await interaction.editReply({ embeds: [embed] })
     } catch (e) {
       await replyWithError(

--- a/apps/discord-bot/src/utils/constants.ts
+++ b/apps/discord-bot/src/utils/constants.ts
@@ -1,13 +1,3 @@
 export const embedFooterDetails = {
   text: 'Rolled with 👹 by randsum.dev'
 }
-
-export const D6_IMAGES = {
-  1: 'https://files.randsum.io/1.jpg',
-  2: 'https://files.randsum.io/2.jpg',
-  3: 'https://files.randsum.io/3.jpg',
-  4: 'https://files.randsum.io/4.jpg',
-  5: 'https://files.randsum.io/5.jpg',
-  6: 'https://files.randsum.io/6.jpg',
-  double6: 'https://files.randsum.io/6-6.jpg'
-} as const

--- a/render.yaml
+++ b/render.yaml
@@ -13,7 +13,7 @@ services:
     # Scope the build to the bot's dependency subtree (roller -> games -> bot)
     # instead of the full-monorepo `bun run build`, which also built the CLI.
     buildCommand: bun install --frozen-lockfile && bun run --filter @randsum/roller --filter @randsum/games --filter @randsum/discord-bot build
-    startCommand: node apps/discord-bot/dist/index.js
+    startCommand: node --enable-source-maps apps/discord-bot/dist/index.js
     envVars:
       # Pin Bun to match .bun-version (1.3.14) so the Render build uses the same
       # toolchain as CI/lefthook (audit X4). The live service was on 1.3.8 —
@@ -25,4 +25,8 @@ services:
       - key: DISCORD_CLIENT_ID
         sync: false
       - key: DISCORD_GUILD_ID
+        sync: false
+      # Sentry DSN for error tracking (read by src/utils/errorTracker.ts).
+      # Optional at runtime — the tracker no-ops when unset.
+      - key: SENTRY_DSN
         sync: false


### PR DESCRIPTION
Fixes a batch of Discord bot defects surfaced by the monorepo deep-dive audit. Scope is limited to `apps/discord-bot/**` and root `render.yaml`.

## Embeds
- **Dead thumbnails removed.** `files.randsum.io` is NXDOMAIN and the referenced image assets do not exist anywhere in the repo, so every `/blades` and `/root` embed shipped a broken thumbnail. Removed `D6_IMAGES` (`src/utils/constants.ts`), `ROOT_IMAGES` (`src/commands/root.ts`), and their `setThumbnail` call sites in `blades.ts`/`root.ts`. Art can be restored later by hosting files under `apps/site/public` on randsum.dev and pointing at those URLs.

## `/fifth` tie rendering
- Kept-die detection previously used `r === Math.max(...initialRolls)` (or `min`), so when both d20s tied, **both** rendered bold and neither was struck through. Now derived from the roll record the roller already returns — the post-modifier `rolls` (kept dice) are matched against `initialRolls` and consumed one-by-one via a `markKeptRolls` helper, so a tie renders exactly one bold + one struck. Added regression tests for the advantage tie, disadvantage tie, and non-tie cases.

## Command consistency
- Added the `hidden` ephemeral option (matching the seven roll commands) to `/help` and `/notation`, and switched both to `deferReplyHonoringHidden`.
- `/help` now derives its command list from the runtime `client.commands` collection (minus `help` itself) instead of a hand-maintained parallel array, so new commands appear automatically. This avoids a circular import with `commands/index.ts` (out of scope for this PR).
- `/root` now uses `interaction.user.displayName` (the variable previously named `memberNick` actually held the raw username, and returned `Unknown` in DMs); variable renamed to `displayName`.
- Replaced the three `components: [row as never]` casts in `notation.ts` with a properly typed `ActionRowBuilder<StringSelectMenuBuilder>`, so the casts disappear.

## Build / deploy
- `bunup.config.ts`: `minify: false` (a long-running worker gains nothing from minification and Render logs showed minified stacks) and `dts: false` (private worker, declarations unused).
- `render.yaml`: added `--enable-source-maps` to the `node` start command and a `SENTRY_DSN` env var with `sync: false` (read by `src/utils/errorTracker.ts`, documented in `.env.example`, previously missing from the blueprint).

## Verification
- `bun run --filter @randsum/discord-bot typecheck` — clean
- `bun run --filter @randsum/discord-bot test` — 70 pass, 0 fail (12 files), including the new tie regression tests
- `bun run --filter @randsum/discord-bot lint` — clean
- `bun run --filter @randsum/discord-bot build` — clean; output is now unminified with a sourcemap and no `.d.ts`
- Pre-push hooks (build, test, audit, sca, knip, arch-check, codegen-check, conformance-check) all passed

From the 2026-07-07 monorepo deep-dive audit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019DMVgLnWbodhurNKcGM1oz