### PR TITLE
feat(games)!: unify result strings to snake_case; spec ergonomics and hermetic codegen

### DIFF
--- a/.changeset/games-snake-case-results.md
+++ b/.changeset/games-snake-case-results.md
@@ -1,0 +1,44 @@
+---
+"@randsum/games": major
+---
+
+Unify every enum-like `result` string to `snake_case` across all seven games, plus spec-ergonomics and hermetic-codegen improvements.
+
+**Breaking — result strings changed.** Previously each game used its own casing convention (blades lowercase, pbta already snake_case, root-rpg Title-Case-with-spaces, fate Title-Case ladder, daggerheart an embedded space). They are now uniformly `snake_case`. Switch on these machine-friendly values and derive human-readable labels at your display layer. Free-text strings from data tables (e.g. Salvage Union's `remoteTableLookup` result text) are data, not enums, and are unchanged.
+
+Full old → new mapping (only changed values are listed; games/values not listed were already `snake_case` or single lowercase words and are unchanged):
+
+| Game           | Old result                                     | New result                         |
+| -------------- | ---------------------------------------------- | ---------------------------------- |
+| `daggerheart`  | `critical hope`                                | `critical_hope`                    |
+| `daggerheart`  | `hope`                                         | `hope` (unchanged)                 |
+| `daggerheart`  | `fear`                                         | `fear` (unchanged)                 |
+| `fate`         | `Legendary`                                    | `legendary`                        |
+| `fate`         | `Epic`                                         | `epic`                             |
+| `fate`         | `Fantastic`                                    | `fantastic`                        |
+| `fate`         | `Superb`                                       | `superb`                           |
+| `fate`         | `Great`                                        | `great`                            |
+| `fate`         | `Good`                                         | `good`                             |
+| `fate`         | `Fair`                                         | `fair`                             |
+| `fate`         | `Average`                                      | `average`                          |
+| `fate`         | `Mediocre`                                     | `mediocre`                         |
+| `fate`         | `Poor`                                         | `poor`                             |
+| `fate`         | `Terrible`                                     | `terrible`                         |
+| `root-rpg`     | `Strong Hit`                                   | `strong_hit`                       |
+| `root-rpg`     | `Weak Hit`                                     | `weak_hit`                         |
+| `root-rpg`     | `Miss`                                         | `miss`                             |
+| `pbta`         | `strong_hit`                                   | `strong_hit` (unchanged)           |
+| `pbta`         | `weak_hit`                                     | `weak_hit` (unchanged)             |
+| `pbta`         | `miss`                                         | `miss` (unchanged)                 |
+| `blades`       | `critical` / `success` / `partial` / `failure` | unchanged (already lowercase)      |
+| `fifth`        | —                                              | no enum result strings (unchanged) |
+| `salvageunion` | remote-table result text                       | unchanged (data, not an enum)      |
+
+The exported result-type unions change accordingly, e.g. `DaggerheartRollResult` is now `'critical_hope' | 'hope' | 'fear'`, `FateRollResult` is the lowercase ladder, and `RootRpgRollResult` is `'strong_hit' | 'weak_hit' | 'miss'`.
+
+**Non-breaking internals bundled in this release:**
+
+- **Open-ended outcome ranges.** pbta and root-rpg replaced hand-computed outcome bounds (`{ min: -11, max: 27 }` / `{ min: -18, max: 32 }`) with the schema's open-ended `min`-only / `max`-only ranges, so the ladders no longer carry brittle magic numbers.
+- **Hermetic codegen.** `bun run gen` no longer hits the network: remote table data (Salvage Union) is read from the checked-in `__fixtures__/<shortcode>-tables.json` snapshot. Pass `--refresh-remote` to explicitly refetch and rewrite the snapshot. Running `gen` twice in a row leaves the tree clean.
+- **`./schema` subpath.** `generateCode` now exposes its `GenerateCodeOptions` second parameter to external consumers, so a caller can inject its own `remoteDataCache`.
+- **ajv strict-mode warning removed** from the validator (`allowUnionTypes: true`).

--- a/apps/discord-bot/__tests__/commands/dh.test.ts
+++ b/apps/discord-bot/__tests__/commands/dh.test.ts
@@ -79,7 +79,7 @@ describe('dhCommand', () => {
 
   test('critical hope result', async () => {
     mockRoll.mockImplementationOnce(() => ({
-      result: 'critical hope' as const,
+      result: 'critical_hope' as const,
       total: 20,
       details: { hope: { roll: 10 }, fear: { roll: 10 }, extraDie: undefined, modifier: 0 },
       rolls: []

--- a/apps/discord-bot/__tests__/commands/fate.test.ts
+++ b/apps/discord-bot/__tests__/commands/fate.test.ts
@@ -2,7 +2,7 @@ import { beforeEach, describe, expect, mock, test } from 'bun:test'
 import type { APIEmbed } from 'discord.js'
 
 const mockRoll = mock((): { result: string; total: number; rolls: unknown[] } => ({
-  result: 'Great',
+  result: 'great',
   total: 4,
   rolls: [{ initialRolls: [1, 1, 0, 1], rolls: [1, 1, 0, 1], modifierLogs: [] }]
 }))

--- a/apps/discord-bot/__tests__/commands/root.test.ts
+++ b/apps/discord-bot/__tests__/commands/root.test.ts
@@ -2,7 +2,7 @@ import { beforeEach, describe, expect, mock, test } from 'bun:test'
 import type { APIEmbed } from 'discord.js'
 
 const mockRoll = mock((): { result: string; total: number; rolls: unknown[] } => ({
-  result: 'Strong Hit',
+  result: 'strong_hit',
   total: 9,
   rolls: [{ initialRolls: [5, 4], rolls: [5, 4], modifierLogs: [] }]
 }))
@@ -48,7 +48,7 @@ describe('rootCommand', () => {
 
   test('Weak Hit', async () => {
     mockRoll.mockImplementationOnce(() => ({
-      result: 'Weak Hit' as const,
+      result: 'weak_hit' as const,
       total: 7,
       rolls: [{ initialRolls: [4, 3], rolls: [4, 3], modifierLogs: [] }]
     }))
@@ -63,7 +63,7 @@ describe('rootCommand', () => {
 
   test('Miss', async () => {
     mockRoll.mockImplementationOnce(() => ({
-      result: 'Miss' as const,
+      result: 'miss' as const,
       total: 3,
       rolls: [{ initialRolls: [2, 1], rolls: [2, 1], modifierLogs: [] }]
     }))

--- a/apps/discord-bot/src/commands/dh.ts
+++ b/apps/discord-bot/src/commands/dh.ts
@@ -21,12 +21,12 @@ function buildDhEmbed({ modifier, rollingWith, amplifyHope, amplifyFear }: DhPar
   })
 
   const color: number =
-    result.result === 'critical hope' ? 0xffd700 : result.result === 'hope' ? 0xffff00 : 0x9b59b6
+    result.result === 'critical_hope' ? 0xffd700 : result.result === 'hope' ? 0xffff00 : 0x9b59b6
 
   const embed = new EmbedBuilder()
     .setColor(color)
     .setTitle(
-      `${result.result === 'critical hope' ? 'Critical ' : ''}${result.result === 'fear' ? 'Fear' : 'Hope'}!`
+      `${result.result === 'critical_hope' ? 'Critical ' : ''}${result.result === 'fear' ? 'Fear' : 'Hope'}!`
     )
     .setDescription(`Total: ${result.total}`)
     .setFooter(embedFooterDetails)

--- a/apps/discord-bot/src/commands/fate.ts
+++ b/apps/discord-bot/src/commands/fate.ts
@@ -9,21 +9,22 @@ import type { Command } from '../types.js'
 const SKILL_MIN = -2
 const SKILL_MAX = 5
 
-// Keyed by the exported FateRollResult union so the ladder-to-colour map stays
-// exhaustive: renaming the result strings (e.g. to snake_case) surfaces here as
-// a type error rather than a silent miss.
-const ladderColors: Record<FateRollResult, number> = {
-  Legendary: 0xffd700,
-  Epic: 0xffd700,
-  Fantastic: 0x2ecc71,
-  Superb: 0x2ecc71,
-  Great: 0x2ecc71,
-  Good: 0x3498db,
-  Fair: 0x3498db,
-  Average: 0x95a5a6,
-  Mediocre: 0x95a5a6,
-  Poor: 0xe67e22,
-  Terrible: 0xe74c3c
+// Keyed by the exported FateRollResult union so the ladder map stays
+// exhaustive: renaming the result strings surfaces here as a type error
+// rather than a silent miss. `label` is the human-readable ladder rung shown
+// to the player; the result strings themselves are snake_case.
+const ladder: Record<FateRollResult, { readonly color: number; readonly label: string }> = {
+  legendary: { color: 0xffd700, label: 'Legendary' },
+  epic: { color: 0xffd700, label: 'Epic' },
+  fantastic: { color: 0x2ecc71, label: 'Fantastic' },
+  superb: { color: 0x2ecc71, label: 'Superb' },
+  great: { color: 0x2ecc71, label: 'Great' },
+  good: { color: 0x3498db, label: 'Good' },
+  fair: { color: 0x3498db, label: 'Fair' },
+  average: { color: 0x95a5a6, label: 'Average' },
+  mediocre: { color: 0x95a5a6, label: 'Mediocre' },
+  poor: { color: 0xe67e22, label: 'Poor' },
+  terrible: { color: 0xe74c3c, label: 'Terrible' }
 }
 
 function fateDieSymbol(die: number): string {
@@ -38,8 +39,8 @@ function buildFateEmbed(skill: number): EmbedBuilder {
   const symbols = dice.map(fateDieSymbol).join('  ')
 
   const embed = new EmbedBuilder()
-    .setColor(ladderColors[result.result])
-    .setTitle(result.result)
+    .setColor(ladder[result.result].color)
+    .setTitle(ladder[result.result].label)
     .setDescription(`Total: ${result.total}`)
     .setFooter(embedFooterDetails)
 

--- a/apps/discord-bot/src/commands/root.ts
+++ b/apps/discord-bot/src/commands/root.ts
@@ -10,19 +10,24 @@ function buildRootEmbed(modifier: number, displayName: string): EmbedBuilder {
   const initialRolls = result.rolls[0]?.initialRolls ?? []
 
   const resultConfig = {
-    'Strong Hit': { color: 0x00ff00, resultDescription: 'You succeed at your goal' },
-    'Weak Hit': {
+    strong_hit: {
+      label: 'Strong Hit',
+      color: 0x00ff00,
+      resultDescription: 'You succeed at your goal'
+    },
+    weak_hit: {
+      label: 'Weak Hit',
       color: 0xffff00,
       resultDescription: 'You succeed, but with a cost or complication'
     },
-    Miss: { color: 0xff0000, resultDescription: "Things don't go your way" }
+    miss: { label: 'Miss', color: 0xff0000, resultDescription: "Things don't go your way" }
   } as const
 
-  const { color, resultDescription } = resultConfig[result.result]
+  const { color, resultDescription, label } = resultConfig[result.result]
 
   const embed = new EmbedBuilder()
     .setColor(color)
-    .setTitle(`${displayName} rolled a ${result.result}`)
+    .setTitle(`${displayName} rolled a ${label}`)
     .setDescription(resultDescription)
     .setFooter(embedFooterDetails)
 

--- a/apps/site/src/content/docs/games/daggerheart.mdx
+++ b/apps/site/src/content/docs/games/daggerheart.mdx
@@ -84,7 +84,7 @@ roll({
 <CodeExample code={`import { roll } from '@randsum/games/daggerheart'
 
 const { result, total, details } = roll({ modifier: 3 })
-// result: 'hope' | 'fear' | 'critical hope'
+// result: 'hope' | 'fear' | 'critical_hope'
 // details: { hope, fear, extraDie, modifier }
 
 const { hope, fear, extraDie, modifier } = details`} />
@@ -106,7 +106,7 @@ const { hope, fear, extraDie, modifier } = details`} />
 
 | Property | Type | Description |
 |---|---|---|
-| `result` | `DaggerheartRollResult` | `'hope' \| 'fear' \| 'critical hope'` |
+| `result` | `DaggerheartRollResult` | `'hope' \| 'fear' \| 'critical_hope'` |
 | `total` | `number` | Sum of all dice + modifier |
 | `details` | `DaggerheartRollDetails` | Detailed breakdown (see below) |
 | `rolls` | `RollRecord[]` | Raw dice data from the core roller |

--- a/apps/site/src/content/docs/games/fate.mdx
+++ b/apps/site/src/content/docs/games/fate.mdx
@@ -46,7 +46,7 @@ The `@randsum/games/fate` subpath provides mechanics for [Fate Core](https://www
 // Roll 4dF with no skill modifier
 const { result, total } = roll()
 console.log(total)  // -4 to +4
-console.log(result) // e.g. 'Mediocre'`} />
+console.log(result) // e.g. 'mediocre'`} />
 
 <CodeExample code={`import { roll } from '@randsum/games/fate'
 
@@ -59,14 +59,14 @@ roll({ modifier: 3 }) // object overload: the same roll`} />
 const { result } = roll({ modifier: 4 })
 
 switch (result) {
-  case 'Legendary':
-  case 'Epic':
-  case 'Fantastic':
+  case 'legendary':
+  case 'epic':
+  case 'fantastic':
     // A standout success
     break
-  case 'Superb':
-  case 'Great':
-  case 'Good':
+  case 'superb':
+  case 'great':
+  case 'good':
     // A solid success
     break
   default:
@@ -98,19 +98,19 @@ Fate dice are six-sided dice with two `+` faces, two blank faces, and two `−` 
 
 | Total | Rung |
 |---|---|
-| +8 or more | `Legendary` |
-| +7 | `Epic` |
-| +6 | `Fantastic` |
-| +5 | `Superb` |
-| +4 | `Great` |
-| +3 | `Good` |
-| +2 | `Fair` |
-| +1 | `Average` |
-| 0 | `Mediocre` |
-| -1 | `Poor` |
-| -2 or less | `Terrible` |
+| +8 or more | `legendary` |
+| +7 | `epic` |
+| +6 | `fantastic` |
+| +5 | `superb` |
+| +4 | `great` |
+| +3 | `good` |
+| +2 | `fair` |
+| +1 | `average` |
+| 0 | `mediocre` |
+| -1 | `poor` |
+| -2 or less | `terrible` |
 
-The open-ended `Legendary` and `Terrible` rungs absorb any total beyond the ends of the ladder.
+The open-ended `legendary` and `terrible` rungs absorb any total beyond the ends of the ladder.
 
 ## Error handling
 

--- a/apps/site/src/content/docs/games/introduction.mdx
+++ b/apps/site/src/content/docs/games/introduction.mdx
@@ -94,8 +94,8 @@ All game packages share these characteristics:
 | `fifth` | 1d20 or 2d20 | `modifier`, `rollingWith`, `crit` | Numeric total |
 | `blades` | Nd6 pool | `rating` (number, 0-6) | `critical`, `success`, `partial`, `failure` |
 | `pbta` | 2d6 | `stat`, `forward`, `ongoing`, `rollingWith` | `strong_hit`, `weak_hit`, `miss` |
-| `daggerheart` | Hope/Fear dice | `modifier`, `amplifyHope`, `amplifyFear`, `rollingWith` | `critical hope`, `hope`, `fear` |
-| `root-rpg` | 2d6 | `bonus` (number) | `Strong Hit`, `Weak Hit`, `Miss` |
+| `daggerheart` | Hope/Fear dice | `modifier`, `amplifyHope`, `amplifyFear`, `rollingWith` | `critical_hope`, `hope`, `fear` |
+| `root-rpg` | 2d6 | `bonus` (number) | `strong_hit`, `weak_hit`, `miss` |
 
 ## Installation
 

--- a/apps/site/src/content/docs/games/root-rpg.mdx
+++ b/apps/site/src/content/docs/games/root-rpg.mdx
@@ -45,20 +45,20 @@ The `@randsum/games/root-rpg` subpath provides mechanics for [Root RPG](https://
 
 // Roll with a stat bonus
 const { result, total } = roll(2)
-// result: 'Strong Hit' | 'Weak Hit' | 'Miss'`} />
+// result: 'strong_hit' | 'weak_hit' | 'miss'`} />
 
 <CodeExample code={`import { roll } from '@randsum/games/root-rpg'
 
 const { result } = roll(0)
 
 switch (result) {
-  case 'Strong Hit':
+  case 'strong_hit':
     // 10+ total: complete success
     break
-  case 'Weak Hit':
+  case 'weak_hit':
     // 7-9 total: partial success with cost
     break
-  case 'Miss':
+  case 'miss':
     // 6- total: failure
     break
 }`} />
@@ -83,7 +83,7 @@ roll(-1)  // Penalty`} />
 
 | Property | Type | Description |
 |---|---|---|
-| `result` | `RootRpgRollResult` | `'Strong Hit' \| 'Weak Hit' \| 'Miss'` |
+| `result` | `RootRpgRollResult` | `'strong_hit' \| 'weak_hit' \| 'miss'` |
 | `total` | `number` | Sum of 2d6 + bonus |
 | `rolls` | `RollRecord[]` | Raw dice data from the core roller |
 
@@ -91,9 +91,9 @@ roll(-1)  // Penalty`} />
 
 | Outcome | Total | Description |
 |---|---|---|
-| `Strong Hit` | 10+ | Complete success -- you achieve your goal |
-| `Weak Hit` | 7-9 | Partial success -- you do it, but with a cost or complication |
-| `Miss` | 6- | Failure -- things go badly |
+| `strong_hit` | 10+ | Complete success -- you achieve your goal |
+| `weak_hit` | 7-9 | Partial success -- you do it, but with a cost or complication |
+| `miss` | 6- | Failure -- things go badly |
 
 ## Error handling
 

--- a/apps/site/src/content/docs/games/schema/reference.mdx
+++ b/apps/site/src/content/docs/games/schema/reference.mdx
@@ -229,7 +229,7 @@ How the roll total is determined.
 <CodeExample lang="json" code={`"resolve": {
   "comparePoolHighest": {
     "pools": ["hope", "fear"],
-    "ties": "critical hope",
+    "ties": "critical_hope",
     "outcomes": { "hope": "hope", "fear": "fear" }
   }
 }`} />

--- a/packages/games/CLAUDE.md
+++ b/packages/games/CLAUDE.md
@@ -13,6 +13,8 @@ Seven games ship: `blades`, `daggerheart`, `fate`, `fifth`, `pbta`, `root-rpg`, 
 
 Each game's `roll()` returns a `GameRollResult<TResult, TDetails, TRollRecord>` with typed `result`, `total`, and `rolls`.
 
+Every enum-like `result` string is `snake_case` across all games (e.g. `strong_hit`, `weak_hit`, `miss`, `critical_hope`, `legendary`). This is a stable, machine-friendly contract — switch on these values in code, and derive any human-readable label (e.g. `"Strong Hit"`) at the display layer. Free-text strings pulled from data tables (e.g. Salvage Union's `remoteTableLookup` result text) are data, not enums, and are left verbatim.
+
 ## Directory Structure
 
 ```
@@ -42,7 +44,7 @@ packages/games/
     <shortcode>.property.test.ts  # Property-based tests per game
     build-smoke.test.ts           # Build output verification
   __fixtures__/
-    salvageunion-tables.json      # Cached remote table data
+    salvageunion-tables.json      # Checked-in remote table snapshot (codegen reads this by default)
 ```
 
 ## .randsum.json Spec Format
@@ -77,12 +79,15 @@ bun run --filter @randsum/games gen:check    # Verify generated files are up to 
 The codegen script (`codegen.ts` at package root):
 
 1. Reads all `*.randsum.json` files from the package root
-2. Resolves external `$ref`s via `resolveExternalRefs` (fetches remote data, e.g. Salvage Union tables, cached to `__fixtures__/<shortcode>-tables.json`)
-3. Validates each resolved spec against the meta-schema via `validateSpec`
-4. Calls `generateCode()` from `src/lib` to produce TypeScript
-5. Formats with Prettier and writes to `src/<shortcode>.generated.ts`, then regenerates `src/availableGames.generated.ts`
+2. Resolves external `$ref`s via `resolveExternalRefs`
+3. Reads remote table data (e.g. Salvage Union tables) from the checked-in `__fixtures__/<shortcode>-tables.json` snapshot — **codegen is hermetic by default and never hits the network**
+4. Validates each resolved spec against the meta-schema via `validateSpec`
+5. Calls `generateCode()` from `src/lib` to produce TypeScript
+6. Formats with Prettier and writes to `src/<shortcode>.generated.ts`, then regenerates `src/availableGames.generated.ts`
 
 Build output: `dist/<shortcode>.generated.js` + `.d.ts` per game. With `--check` (`gen:check`), the script writes nothing and fails if any generated file is stale.
+
+Remote fixtures are refreshed only on demand: `bun run --filter @randsum/games gen -- --refresh-remote` refetches from the source URL and rewrites the `__fixtures__/<shortcode>-tables.json` snapshot. Plain `gen` and `gen:check` are offline and deterministic — running `gen` twice in a row leaves the tree clean.
 
 Generated files import from `@randsum/roller/roll` and `@randsum/roller/validate`. Each exports a typed `roll()` function, a game-specific result type (e.g. `BladesRollResult`), the `SchemaError` value, and re-exports the types `GameRollResult`, `RollRecord`, `SchemaErrorCode`. The salvageunion module additionally exports the `ROLL_TABLE_ENTRIES` and `VALID_TABLE_NAMES` values.
 
@@ -124,7 +129,7 @@ bun run --filter @randsum/games check        # Full check (build + typecheck + f
 - Generated files are checked in but must not be manually edited. Always regenerate via codegen.
 - Games depend only on `@randsum/roller`. Games never depend on each other.
 - Bundle size limit: 15 KB per game (16 KB for daggerheart and pbta; 33 KB for salvageunion due to baked-in tables).
-- Remote data (e.g., Salvage Union tables) is fetched at codegen time and baked into generated code. Zero runtime network calls.
+- Remote data (e.g., Salvage Union tables) is read from the checked-in `__fixtures__/` snapshot at codegen time and baked into generated code. Codegen is hermetic (no network) unless `--refresh-remote` is passed; zero runtime network calls either way.
 
 For the formal modifier taxonomy and classification system, see https://notation.randsum.dev.
 

--- a/packages/games/README.md
+++ b/packages/games/README.md
@@ -44,7 +44,7 @@ const { result } = roll({ modifier: 5, rollingWith: "Advantage" })
 import { roll } from "@randsum/games/fate"
 
 const { result } = roll({ modifier: 2 })
-// result: ladder rung, e.g. 'Average' | 'Fair' | 'Good' | 'Great' | 'Superb' | ...
+// result: ladder rung, e.g. 'average' | 'fair' | 'good' | 'great' | 'superb' | ...
 ```
 
 ```typescript
@@ -58,14 +58,14 @@ const { result } = roll({ stat: 2 })
 import { roll } from "@randsum/games/daggerheart"
 
 const { result } = roll({ modifier: 3 })
-// result: 'hope' | 'fear' | 'critical hope'
+// result: 'hope' | 'fear' | 'critical_hope'
 ```
 
 ```typescript
 import { roll } from "@randsum/games/root-rpg"
 
 const { result } = roll({ modifier: 2 })
-// result: 'Strong Hit' | 'Weak Hit' | 'Miss'
+// result: 'strong_hit' | 'weak_hit' | 'miss'
 ```
 
 ```typescript

--- a/packages/games/__tests__/daggerheart.property.test.ts
+++ b/packages/games/__tests__/daggerheart.property.test.ts
@@ -7,7 +7,7 @@ describe('roll property-based tests', () => {
     fc.assert(
       fc.property(fc.integer({ min: -20, max: 20 }), modifier => {
         const { result } = roll({ modifier })
-        return ['hope', 'fear', 'critical hope'].includes(result)
+        return ['hope', 'fear', 'critical_hope'].includes(result)
       })
     )
   })

--- a/packages/games/__tests__/daggerheart.test.ts
+++ b/packages/games/__tests__/daggerheart.test.ts
@@ -5,7 +5,7 @@ import { STRESS_ITERATIONS } from './stressIterations'
 describe('roll', () => {
   describe('basic functionality', () => {
     test('returns valid roll types', () => {
-      const validTypes = ['hope', 'fear', 'critical hope']
+      const validTypes = ['hope', 'fear', 'critical_hope']
 
       Array.from({ length: 20 }).forEach(() => {
         const result = roll({})
@@ -125,16 +125,16 @@ describe('roll', () => {
   //
   // The generated roll() does not expose a randomFn option, so seeded injection
   // is not available at the game API layer. We use stress testing to confirm that
-  // 'critical hope' (hopeTotal === fearTotal) is reachable when both dice are d20.
+  // 'critical_hope' (hopeTotal === fearTotal) is reachable when both dice are d20.
   describe('critical hope with amplified dice', () => {
     test('critical hope is reachable with amplifyHope: true and amplifyFear: true', () => {
       const results = Array.from({ length: STRESS_ITERATIONS }, () =>
         roll({ amplifyHope: true, amplifyFear: true })
       )
-      const criticalHope = results.find(r => r.result === 'critical hope')
+      const criticalHope = results.find(r => r.result === 'critical_hope')
       // With 9999 rolls, the chance of never rolling equal values on 2d20 is negligible
       expect(criticalHope).toBeDefined()
-      expect(criticalHope?.result).toBe('critical hope')
+      expect(criticalHope?.result).toBe('critical_hope')
       expect(criticalHope?.details?.hope.amplified).toBe(true)
       expect(criticalHope?.details?.fear.amplified).toBe(true)
       expect(criticalHope?.details?.hope.roll).toBe(criticalHope?.details?.fear.roll)

--- a/packages/games/__tests__/fate.property.test.ts
+++ b/packages/games/__tests__/fate.property.test.ts
@@ -3,17 +3,17 @@ import fc from 'fast-check'
 import { roll } from '@randsum/games/fate'
 
 const LADDER = [
-  'Legendary',
-  'Epic',
-  'Fantastic',
-  'Superb',
-  'Great',
-  'Good',
-  'Fair',
-  'Average',
-  'Mediocre',
-  'Poor',
-  'Terrible'
+  'legendary',
+  'epic',
+  'fantastic',
+  'superb',
+  'great',
+  'good',
+  'fair',
+  'average',
+  'mediocre',
+  'poor',
+  'terrible'
 ]
 
 describe('roll property-based tests', () => {

--- a/packages/games/__tests__/fate.test.ts
+++ b/packages/games/__tests__/fate.test.ts
@@ -3,17 +3,17 @@ import { roll } from '@randsum/games/fate'
 import { STRESS_ITERATIONS } from './stressIterations'
 
 const LADDER = [
-  'Legendary',
-  'Epic',
-  'Fantastic',
-  'Superb',
-  'Great',
-  'Good',
-  'Fair',
-  'Average',
-  'Mediocre',
-  'Poor',
-  'Terrible'
+  'legendary',
+  'epic',
+  'fantastic',
+  'superb',
+  'great',
+  'good',
+  'fair',
+  'average',
+  'mediocre',
+  'poor',
+  'terrible'
 ] as const
 
 describe('roll', () => {
@@ -79,17 +79,17 @@ describe('roll', () => {
 
   describe('ladder rung classification', () => {
     test.each([
-      [8, 'Legendary'],
-      [7, 'Epic'],
-      [6, 'Fantastic'],
-      [5, 'Superb'],
-      [4, 'Great'],
-      [3, 'Good'],
-      [2, 'Fair'],
-      [1, 'Average'],
-      [0, 'Mediocre'],
-      [-1, 'Poor'],
-      [-2, 'Terrible']
+      [8, 'legendary'],
+      [7, 'epic'],
+      [6, 'fantastic'],
+      [5, 'superb'],
+      [4, 'great'],
+      [3, 'good'],
+      [2, 'fair'],
+      [1, 'average'],
+      [0, 'mediocre'],
+      [-1, 'poor'],
+      [-2, 'terrible']
     ] as const)('a total of %d maps to %s', (total, expected) => {
       // Hold the modifier near the target total and sample rolls until the exact total appears,
       // then assert the rung. Terrible/Legendary clamp the open-ended ends of the ladder.

--- a/packages/games/__tests__/root-rpg.property.test.ts
+++ b/packages/games/__tests__/root-rpg.property.test.ts
@@ -2,11 +2,11 @@ import { describe, test } from 'bun:test'
 import fc from 'fast-check'
 import { roll } from '@randsum/games/root-rpg'
 
-const VALID_RESULTS = ['Strong Hit', 'Weak Hit', 'Miss'] as const
+const VALID_RESULTS = ['strong_hit', 'weak_hit', 'miss'] as const
 
 const resultTier = (result: (typeof VALID_RESULTS)[number]): number => {
-  if (result === 'Strong Hit') return 2
-  if (result === 'Weak Hit') return 1
+  if (result === 'strong_hit') return 2
+  if (result === 'weak_hit') return 1
   return 0
 }
 
@@ -33,9 +33,9 @@ describe('roll property-based tests', () => {
     fc.assert(
       fc.property(fc.integer({ min: -3, max: 5 }), bonus => {
         const { result, total } = roll({ bonus })
-        if (total >= 10) return result === 'Strong Hit'
-        if (total >= 7) return result === 'Weak Hit'
-        return result === 'Miss'
+        if (total >= 10) return result === 'strong_hit'
+        if (total >= 7) return result === 'weak_hit'
+        return result === 'miss'
       })
     )
   })

--- a/packages/games/__tests__/root-rpg.test.ts
+++ b/packages/games/__tests__/root-rpg.test.ts
@@ -44,12 +44,12 @@ describe('roll', () => {
       const dummyArray = Array.from({ length: STRESS_ITERATIONS }, () => roll({ bonus: 0 }))
 
       dummyArray.forEach(({ result, total }) => {
-        if (result === 'Strong Hit') {
+        if (result === 'strong_hit') {
           expect(total).toBeGreaterThanOrEqual(10)
           return
         }
 
-        if (result === 'Weak Hit') {
+        if (result === 'weak_hit') {
           expect(total).toBeGreaterThanOrEqual(7)
           expect(total).toBeLessThanOrEqual(9)
           return
@@ -150,14 +150,14 @@ describe('roll', () => {
 
     test('handles maximum valid positive modifier', () => {
       const { result, total } = roll({ bonus: 5 })
-      expect(['Strong Hit', 'Weak Hit', 'Miss']).toContain(result)
+      expect(['strong_hit', 'weak_hit', 'miss']).toContain(result)
       expect(total).toBeGreaterThanOrEqual(7) // 2d6 minimum (2) + 5
       expect(total).toBeLessThanOrEqual(17) // 2d6 maximum (12) + 5
     })
 
     test('handles maximum valid negative modifier', () => {
       const { result, total } = roll({ bonus: -3 })
-      expect(['Strong Hit', 'Weak Hit', 'Miss']).toContain(result)
+      expect(['strong_hit', 'weak_hit', 'miss']).toContain(result)
       expect(total).toBeGreaterThanOrEqual(-1) // 2d6 minimum (2) - 3
       expect(total).toBeLessThanOrEqual(9) // 2d6 maximum (12) - 3
     })

--- a/packages/games/codegen.ts
+++ b/packages/games/codegen.ts
@@ -4,13 +4,17 @@ import { join } from 'node:path'
 
 import { format, resolveConfig } from 'prettier'
 
-import { generateCode, resolveExternalRefs, validateSpec } from './src/lib'
+import { generateCode, getRollDefinitions, resolveExternalRefs, validateSpec } from './src/lib'
 import type { RandSumSpec } from './src/lib'
 
 const packageDir = import.meta.dirname
 const srcDir = join(packageDir, 'src')
 const fixturesDir = join(packageDir, '__fixtures__')
 const checkMode = process.argv.includes('--check')
+// By default codegen is hermetic: remote table data is read from the
+// checked-in __fixtures__ snapshot. Pass --refresh-remote to refetch from the
+// network and rewrite the fixture.
+const refreshRemote = process.argv.includes('--refresh-remote')
 
 async function formatCode(code: string, filepath: string): Promise<string> {
   const config = await resolveConfig(filepath)
@@ -22,8 +26,7 @@ function fixturePathFor(shortcode: string): string {
 }
 
 function getRemoteUrl(spec: RandSumSpec): string | undefined {
-  const rollDefs = spec.rolls ?? (spec.roll !== undefined ? { roll: spec.roll } : {})
-  for (const rollDef of Object.values(rollDefs)) {
+  for (const rollDef of Object.values(getRollDefinitions(spec))) {
     const resolve = rollDef.resolve
     if (typeof resolve === 'object' && 'remoteTableLookup' in resolve) {
       const { url } = resolve.remoteTableLookup
@@ -64,7 +67,7 @@ async function main(): Promise<void> {
     const remoteUrl = getRemoteUrl(spec)
     const remoteDataCache = new Map<string, readonly unknown[]>()
 
-    if (remoteUrl && !checkMode) {
+    if (remoteUrl && refreshRemote && !checkMode) {
       const response = await fetch(remoteUrl)
       if (!response.ok) {
         console.error(`FAIL  fetch ${remoteUrl}: HTTP ${String(response.status)}`)
@@ -75,12 +78,12 @@ async function main(): Promise<void> {
 
       mkdirSync(fixturesDir, { recursive: true })
       writeFileSync(fixturePathFor(spec.shortcode), JSON.stringify(data, null, 2) + '\n', 'utf-8')
-      console.log(`  fixture: __fixtures__/${spec.shortcode}-tables.json`)
-    } else if (remoteUrl && checkMode) {
+      console.log(`  fixture: __fixtures__/${spec.shortcode}-tables.json (refreshed from remote)`)
+    } else if (remoteUrl) {
       const fixturePath = fixturePathFor(spec.shortcode)
       if (!existsSync(fixturePath)) {
         console.error(
-          `FAIL  missing fixture ${fixturePath}. Run \`bun run codegen\` to generate it.`
+          `FAIL  missing fixture ${fixturePath}. Run \`bun run codegen --refresh-remote\` to generate it.`
         )
         process.exit(1)
       }

--- a/packages/games/daggerheart.randsum.json
+++ b/packages/games/daggerheart.randsum.json
@@ -36,7 +36,7 @@
     "resolve": {
       "comparePoolHighest": {
         "pools": ["hope", "fear"],
-        "ties": "critical hope",
+        "ties": "critical_hope",
         "outcomes": { "hope": "hope", "fear": "fear" }
       }
     },

--- a/packages/games/docs/codegen-extension.md
+++ b/packages/games/docs/codegen-extension.md
@@ -64,7 +64,7 @@ All paths are relative to `packages/games/`.
 | `src/lib/normalizer.ts` | Pure function `normalizeSpec(spec: RandSumSpec): NormalizedSpec`. Resolves every `$ref`, collapses sugar, tags discriminated unions with `kind`. |
 | `src/lib/refResolver.ts` | Typed `$ref` resolvers. Three entry points: `resolvePoolRef`, `resolveTableRef`, `resolveOutcomeRef`. Each narrows to its target type or throws `SchemaError('REF_NOT_FOUND')`. ~83 lines. |
 | `src/lib/typeGuards.ts` | `getRollDefinitions(spec)` (returns `{ roll: spec.roll }`), plus `isDetailsLeaf` / `isConditionalDetails` / `isInputRef` / `isConditionalRef`. |
-| `src/lib/codegen.ts` | `generateCode(spec, options)` — top-level codegen entry. Detects `remoteTableLookup`, fetches or reads remote data, strips unused fields, assembles imports, delegates per-roll emission. |
+| `src/lib/codegen.ts` | `generateCode(spec, options)` — top-level codegen entry. Detects `remoteTableLookup`, reads remote data from the `options.remoteDataCache` (populated hermetically from `__fixtures__/` by `codegen.ts`) or falls back to a fetch, strips unused fields, assembles imports, delegates per-roll emission. |
 | `src/lib/codegen/emitBody.ts` | `generateRollParts(key, rollDef, …)`. Emits the function body, overloads, and result type. Delegates to `emitModifiers`, `emitOutcome`, `emitDetails`. |
 | `src/lib/codegen/emitModifiers.ts` | Translates `modify[]` entries to roller `RollOptions.modifiers` literals. |
 | `src/lib/codegen/emitOutcome.ts` | Emits outcome-classification logic (`ranges` / `degreeOfSuccess` / `tableLookup` / result-mapping leaves). |

--- a/packages/games/docs/randsum-json-schema.md
+++ b/packages/games/docs/randsum-json-schema.md
@@ -467,12 +467,13 @@ Opaque vs. numeric results:
 ### 5.3 `remoteTableLookup` — build-time tables
 
 The `remoteTableLookup` resolver embeds a remote JSON dataset into the
-generated module. At codegen time, `packages/games/codegen.ts:59-84`
-fetches the URL, writes the JSON to
-`packages/games/__fixtures__/<shortcode>-tables.json` for the
-`gen:check` CI path, and passes the dataset to the emitter. The generated
-module ships with the full table baked into the JS bundle. At runtime the
-module never hits the network.
+generated module. Codegen is hermetic: by default `packages/games/codegen.ts`
+reads the checked-in snapshot at
+`packages/games/__fixtures__/<shortcode>-tables.json` and passes the dataset
+to the emitter — no network access. Pass `--refresh-remote` to refetch from
+the source URL and rewrite that snapshot. The generated module ships with the
+full table baked into the JS bundle, so at runtime the module never hits the
+network either.
 
 The shape (`randsum.json:557-602`):
 
@@ -732,7 +733,7 @@ discussion.
 ### 7.5 Hope and Fear duel (Daggerheart)
 
 Two named pools, resolved by comparing the highest single die between them;
-a tie becomes `"critical hope"`.
+a tie becomes `"critical_hope"`.
 
 `packages/games/daggerheart.randsum.json:20-42`:
 
@@ -744,7 +745,7 @@ a tie becomes `"critical hope"`.
 "resolve": {
   "comparePoolHighest": {
     "pools":    ["hope", "fear"],
-    "ties":     "critical hope",
+    "ties":     "critical_hope",
     "outcomes": { "hope": "hope", "fear": "fear" }
   }
 }
@@ -789,9 +790,9 @@ compare against 10+ / 7-9 / 6-. Root RPG is the minimal version
 "modify":  [{ "add": { "$input": "bonus" } }],
 "outcome": {
   "ranges": [
-    { "min": 10, "max": 32, "result": "Strong Hit" },
-    { "min": 7,  "max": 9,  "result": "Weak Hit" },
-    { "min": -18, "max": 6, "result": "Miss" }
+    { "min": 10, "result": "strong_hit" },
+    { "min": 7, "max": 9, "result": "weak_hit" },
+    { "max": 6, "result": "miss" }
   ]
 }
 ```

--- a/packages/games/fate.randsum.json
+++ b/packages/games/fate.randsum.json
@@ -13,17 +13,17 @@
   "outcomes": {
     "ladder": {
       "ranges": [
-        { "min": 8, "result": "Legendary" },
-        { "exact": 7, "result": "Epic" },
-        { "exact": 6, "result": "Fantastic" },
-        { "exact": 5, "result": "Superb" },
-        { "exact": 4, "result": "Great" },
-        { "exact": 3, "result": "Good" },
-        { "exact": 2, "result": "Fair" },
-        { "exact": 1, "result": "Average" },
-        { "exact": 0, "result": "Mediocre" },
-        { "exact": -1, "result": "Poor" },
-        { "max": -2, "result": "Terrible" }
+        { "min": 8, "result": "legendary" },
+        { "exact": 7, "result": "epic" },
+        { "exact": 6, "result": "fantastic" },
+        { "exact": 5, "result": "superb" },
+        { "exact": 4, "result": "great" },
+        { "exact": 3, "result": "good" },
+        { "exact": 2, "result": "fair" },
+        { "exact": 1, "result": "average" },
+        { "exact": 0, "result": "mediocre" },
+        { "exact": -1, "result": "poor" },
+        { "max": -2, "result": "terrible" }
       ]
     }
   },

--- a/packages/games/pbta.randsum.json
+++ b/packages/games/pbta.randsum.json
@@ -27,9 +27,9 @@
     },
     "outcome": {
       "ranges": [
-        { "min": 10, "max": 27, "result": "strong_hit" },
+        { "min": 10, "result": "strong_hit" },
         { "min": 7, "max": 9, "result": "weak_hit" },
-        { "min": -11, "max": 6, "result": "miss" }
+        { "max": 6, "result": "miss" }
       ]
     },
     "when": [

--- a/packages/games/root-rpg.randsum.json
+++ b/packages/games/root-rpg.randsum.json
@@ -15,9 +15,9 @@
     "modify": [{ "add": { "$input": "bonus" } }],
     "outcome": {
       "ranges": [
-        { "min": 10, "max": 32, "result": "Strong Hit" },
-        { "min": 7, "max": 9, "result": "Weak Hit" },
-        { "min": -18, "max": 6, "result": "Miss" }
+        { "min": 10, "result": "strong_hit" },
+        { "min": 7, "max": 9, "result": "weak_hit" },
+        { "max": 6, "result": "miss" }
       ]
     },
     "when": [

--- a/packages/games/src/daggerheart.generated.ts
+++ b/packages/games/src/daggerheart.generated.ts
@@ -7,7 +7,7 @@ import type { GameRollResult } from './types'
 import { SchemaError } from './lib/errors'
 import type { SchemaErrorCode } from './lib/errors'
 
-export type DaggerheartRollResult = 'critical hope' | 'fear' | 'hope'
+export type DaggerheartRollResult = 'critical_hope' | 'fear' | 'hope'
 
 export interface DaggerheartRollDetails {
   readonly hope: { readonly roll: number; readonly amplified: boolean }
@@ -71,7 +71,7 @@ export function roll(input?: {
           }
         : undefined
   }
-  if (hopeTotal === fearTotal) return { total, result: 'critical hope', rolls, details }
+  if (hopeTotal === fearTotal) return { total, result: 'critical_hope', rolls, details }
   if (hopeTotal > fearTotal) return { total, result: 'hope', rolls, details }
   return { total, result: 'fear', rolls, details }
 }

--- a/packages/games/src/fate.generated.ts
+++ b/packages/games/src/fate.generated.ts
@@ -8,17 +8,17 @@ import { SchemaError } from './lib/errors'
 import type { SchemaErrorCode } from './lib/errors'
 
 export type FateRollResult =
-  | 'Average'
-  | 'Epic'
-  | 'Fair'
-  | 'Fantastic'
-  | 'Good'
-  | 'Great'
-  | 'Legendary'
-  | 'Mediocre'
-  | 'Poor'
-  | 'Superb'
-  | 'Terrible'
+  | 'average'
+  | 'epic'
+  | 'fair'
+  | 'fantastic'
+  | 'good'
+  | 'great'
+  | 'legendary'
+  | 'mediocre'
+  | 'poor'
+  | 'superb'
+  | 'terrible'
 
 export function roll(modifier?: number): GameRollResult<FateRollResult, undefined, RollRecord>
 export function roll(input?: {
@@ -43,17 +43,17 @@ export function roll(
     )
   const r = executeRoll(`${4}d{-1,0,1}`)
   const total = r.total + (input?.modifier ?? 0)
-  if (total >= 8) return { total, result: 'Legendary', rolls: r.rolls }
-  if (total === 7) return { total, result: 'Epic', rolls: r.rolls }
-  if (total === 6) return { total, result: 'Fantastic', rolls: r.rolls }
-  if (total === 5) return { total, result: 'Superb', rolls: r.rolls }
-  if (total === 4) return { total, result: 'Great', rolls: r.rolls }
-  if (total === 3) return { total, result: 'Good', rolls: r.rolls }
-  if (total === 2) return { total, result: 'Fair', rolls: r.rolls }
-  if (total === 1) return { total, result: 'Average', rolls: r.rolls }
-  if (total === 0) return { total, result: 'Mediocre', rolls: r.rolls }
-  if (total === -1) return { total, result: 'Poor', rolls: r.rolls }
-  if (total <= -2) return { total, result: 'Terrible', rolls: r.rolls }
+  if (total >= 8) return { total, result: 'legendary', rolls: r.rolls }
+  if (total === 7) return { total, result: 'epic', rolls: r.rolls }
+  if (total === 6) return { total, result: 'fantastic', rolls: r.rolls }
+  if (total === 5) return { total, result: 'superb', rolls: r.rolls }
+  if (total === 4) return { total, result: 'great', rolls: r.rolls }
+  if (total === 3) return { total, result: 'good', rolls: r.rolls }
+  if (total === 2) return { total, result: 'fair', rolls: r.rolls }
+  if (total === 1) return { total, result: 'average', rolls: r.rolls }
+  if (total === 0) return { total, result: 'mediocre', rolls: r.rolls }
+  if (total === -1) return { total, result: 'poor', rolls: r.rolls }
+  if (total <= -2) return { total, result: 'terrible', rolls: r.rolls }
   throw new SchemaError(`No table entry matches total ${total}`, 'NO_TABLE_MATCH')
 }
 

--- a/packages/games/src/lib/index.ts
+++ b/packages/games/src/lib/index.ts
@@ -1,4 +1,6 @@
 export { resolveExternalRefs } from './externalRefResolver'
 export { generateCode } from './codegen'
+export type { GenerateCodeOptions } from './codegen'
 export { validateSpec } from './validator'
+export { getRollDefinitions } from './typeGuards'
 export type { RandSumSpec } from './types'

--- a/packages/games/src/lib/validator.ts
+++ b/packages/games/src/lib/validator.ts
@@ -11,7 +11,7 @@ export type ValidationResult =
   | { readonly valid: true }
   | { readonly valid: false; readonly errors: readonly ValidationError[] }
 
-const ajv = new Ajv({ allErrors: true })
+const ajv = new Ajv({ allErrors: true, allowUnionTypes: true })
 const _validate = ajv.compile(schema)
 
 export function validateSpec(spec: unknown): ValidationResult {

--- a/packages/games/src/pbta.generated.ts
+++ b/packages/games/src/pbta.generated.ts
@@ -58,9 +58,9 @@ export function roll(input: {
       ongoing: input.ongoing ?? 0,
       diceTotal: diceTotal
     }
-    if (total >= 10 && total <= 27) return { total, result: 'strong_hit', rolls: r.rolls, details }
+    if (total >= 10) return { total, result: 'strong_hit', rolls: r.rolls, details }
     if (total >= 7 && total <= 9) return { total, result: 'weak_hit', rolls: r.rolls, details }
-    if (total >= -11 && total <= 6) return { total, result: 'miss', rolls: r.rolls, details }
+    if (total <= 6) return { total, result: 'miss', rolls: r.rolls, details }
     throw new SchemaError(`No table entry matches total ${total}`, 'NO_TABLE_MATCH')
   }
   if (input.rollingWith === 'Disadvantage') {
@@ -80,9 +80,9 @@ export function roll(input: {
       ongoing: input.ongoing ?? 0,
       diceTotal: diceTotal
     }
-    if (total >= 10 && total <= 27) return { total, result: 'strong_hit', rolls: r.rolls, details }
+    if (total >= 10) return { total, result: 'strong_hit', rolls: r.rolls, details }
     if (total >= 7 && total <= 9) return { total, result: 'weak_hit', rolls: r.rolls, details }
-    if (total >= -11 && total <= 6) return { total, result: 'miss', rolls: r.rolls, details }
+    if (total <= 6) return { total, result: 'miss', rolls: r.rolls, details }
     throw new SchemaError(`No table entry matches total ${total}`, 'NO_TABLE_MATCH')
   }
   const r = executeRoll({
@@ -98,9 +98,9 @@ export function roll(input: {
     ongoing: input.ongoing ?? 0,
     diceTotal: diceTotal
   }
-  if (total >= 10 && total <= 27) return { total, result: 'strong_hit', rolls: r.rolls, details }
+  if (total >= 10) return { total, result: 'strong_hit', rolls: r.rolls, details }
   if (total >= 7 && total <= 9) return { total, result: 'weak_hit', rolls: r.rolls, details }
-  if (total >= -11 && total <= 6) return { total, result: 'miss', rolls: r.rolls, details }
+  if (total <= 6) return { total, result: 'miss', rolls: r.rolls, details }
   throw new SchemaError(`No table entry matches total ${total}`, 'NO_TABLE_MATCH')
 }
 

--- a/packages/games/src/root-rpg.generated.ts
+++ b/packages/games/src/root-rpg.generated.ts
@@ -7,7 +7,7 @@ import type { GameRollResult } from './types'
 import { SchemaError } from './lib/errors'
 import type { SchemaErrorCode } from './lib/errors'
 
-export type RootRpgRollResult = 'Miss' | 'Strong Hit' | 'Weak Hit'
+export type RootRpgRollResult = 'miss' | 'strong_hit' | 'weak_hit'
 
 export function roll(input: {
   bonus: number
@@ -30,9 +30,9 @@ export function roll(input: {
       modifiers: { keep: { highest: 2 }, plus: input.bonus }
     })
     const total = r.total
-    if (total >= 10 && total <= 32) return { total, result: 'Strong Hit', rolls: r.rolls }
-    if (total >= 7 && total <= 9) return { total, result: 'Weak Hit', rolls: r.rolls }
-    if (total >= -18 && total <= 6) return { total, result: 'Miss', rolls: r.rolls }
+    if (total >= 10) return { total, result: 'strong_hit', rolls: r.rolls }
+    if (total >= 7 && total <= 9) return { total, result: 'weak_hit', rolls: r.rolls }
+    if (total <= 6) return { total, result: 'miss', rolls: r.rolls }
     throw new SchemaError(`No table entry matches total ${total}`, 'NO_TABLE_MATCH')
   }
   if (input.rollingWith === 'Disadvantage') {
@@ -42,16 +42,16 @@ export function roll(input: {
       modifiers: { keep: { lowest: 2 }, plus: input.bonus }
     })
     const total = r.total
-    if (total >= 10 && total <= 32) return { total, result: 'Strong Hit', rolls: r.rolls }
-    if (total >= 7 && total <= 9) return { total, result: 'Weak Hit', rolls: r.rolls }
-    if (total >= -18 && total <= 6) return { total, result: 'Miss', rolls: r.rolls }
+    if (total >= 10) return { total, result: 'strong_hit', rolls: r.rolls }
+    if (total >= 7 && total <= 9) return { total, result: 'weak_hit', rolls: r.rolls }
+    if (total <= 6) return { total, result: 'miss', rolls: r.rolls }
     throw new SchemaError(`No table entry matches total ${total}`, 'NO_TABLE_MATCH')
   }
   const r = executeRoll({ sides: 6, quantity: 2, modifiers: { plus: input.bonus } })
   const total = r.total
-  if (total >= 10 && total <= 32) return { total, result: 'Strong Hit', rolls: r.rolls }
-  if (total >= 7 && total <= 9) return { total, result: 'Weak Hit', rolls: r.rolls }
-  if (total >= -18 && total <= 6) return { total, result: 'Miss', rolls: r.rolls }
+  if (total >= 10) return { total, result: 'strong_hit', rolls: r.rolls }
+  if (total >= 7 && total <= 9) return { total, result: 'weak_hit', rolls: r.rolls }
+  if (total <= 6) return { total, result: 'miss', rolls: r.rolls }
   throw new SchemaError(`No table entry matches total ${total}`, 'NO_TABLE_MATCH')
 }
 

--- a/packages/games/src/schema.ts
+++ b/packages/games/src/schema.ts
@@ -6,6 +6,7 @@
 // the type system while satisfying isolatedDeclarations.
 import { resolveExternalRefs as _resolveExternalRefs } from './lib/externalRefResolver'
 import { generateCode as _generateCode, specToFilename as _specToFilename } from './lib/codegen'
+import type { GenerateCodeOptions } from './lib/codegen'
 import { validateSpec as _validateSpec } from './lib/validator'
 import { SchemaError as _SchemaError } from './lib/errors'
 import { lookupByRange as _lookupByRange } from './lib/lookupByRange'
@@ -14,7 +15,8 @@ import type { RandSumSpec } from './lib/types'
 import type { ValidationResult } from './lib/validator'
 
 export const resolveExternalRefs: (spec: RandSumSpec) => Promise<RandSumSpec> = _resolveExternalRefs
-export const generateCode: (spec: RandSumSpec) => Promise<string> = _generateCode
+export const generateCode: (spec: RandSumSpec, options?: GenerateCodeOptions) => Promise<string> =
+  _generateCode
 export const specToFilename: (name: string) => string = _specToFilename
 export const validateSpec: (spec: unknown) => ValidationResult = _validateSpec
 export const SchemaError: typeof _SchemaError = _SchemaError
@@ -26,6 +28,7 @@ export const lookupByRange: (
   readonly result: { readonly label?: string | undefined; readonly value?: string | undefined }
 } = _lookupByRange
 
+export type { GenerateCodeOptions } from './lib/codegen'
 export type { SchemaErrorCode } from './lib/errors'
 export type { ValidationResult, ValidationError } from './lib/validator'
 export type {


### PR DESCRIPTION
## What

BREAKING casing unification across all seven `@randsum/games` specs, plus bundled spec-ergonomics and hermetic-codegen improvements (all one package, so one release).

### Result strings → `snake_case`
Every enum-like outcome `result` string is now uniformly `snake_case`:

| Game | Old | New |
| --- | --- | --- |
| daggerheart | `critical hope` | `critical_hope` |
| fate | `Legendary` … `Terrible` (whole ladder) | `legendary` … `terrible` |
| root-rpg | `Strong Hit` / `Weak Hit` / `Miss` | `strong_hit` / `weak_hit` / `miss` |
| pbta / blades | already conformant | unchanged |
| fifth | no enum results | unchanged |
| salvageunion | remote-table free text | unchanged (data, not an enum) |

Result-type unions (`DaggerheartRollResult`, `FateRollResult`, `RootRpgRollResult`) change accordingly.

### Bot + docs
- Discord bot commands (`root.ts`, `fate.ts`, `dh.ts`) now switch on the new `snake_case` values and derive human-readable labels (`"Strong Hit"`, ladder-rung display) at the display layer. Bot tests updated to mock the new values while still asserting the human-readable rendered titles.
- Site docs (`root-rpg.mdx`, `fate.mdx`, `daggerheart.mdx`, `introduction.mdx`) code examples/value tables updated; narrative prose left human-readable.

### Spec ergonomics (bundled)
- **Open-ended ranges** — pbta/root-rpg drop hand-computed bounds (`{min:-11,max:27}` / `{min:-18,max:32}`) for the schema's open-ended `min`-only / `max`-only ranges.
- **ajv** — `allowUnionTypes: true` silences the strict-mode warning printed on every run.
- **Hermetic codegen** — `bun run gen` reads the checked-in `__fixtures__/salvageunion-tables.json` snapshot by default and never hits the network; a new `--refresh-remote` flag does the explicit refetch/rewrite (check mode already worked this way).
- **codegen.ts** — replaced the `getRemoteUrl` inline shape-probe with the existing `getRollDefinitions` type guard.
- **`./schema` subpath** — `generateCode` now passes `GenerateCodeOptions` through (exported), so external consumers can inject their own `remoteDataCache`.

### Changeset
MAJOR bump for `@randsum/games`, including the full old→new mapping table.

## Why
pbta and root-rpg implemented the same PbtA move with different result vocabularies, and five games each used a different casing convention. `snake_case` gives one machine-friendly contract across the ecosystem; display strings are derived at the UI layer. The bundled spec/codegen changes remove brittle magic-number bounds and make codegen deterministic and offline.

## Verification
- `gen` + `gen:check`: clean; running `gen` twice leaves the tree clean and `__fixtures__/` untouched (hermetic confirmed).
- Games tests: 478 pass / 0 fail.
- Bot tests (roller + games built first): 76 pass / 0 fail.
- Lint (games + bot): clean. Typecheck (games + bot): clean.
- No ajv strict-mode warning on `gen`.
- Pre-push hooks (build, gen-check, conformance, tests, audit, knip, arch) all passed — no `--no-verify`.

From the 2026-07-07 monorepo deep-dive audit (Wave 2).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019DMVgLnWbodhurNKcGM1oz