### PR TITLE
docs(site): document @randsum/mcp; refresh llms.txt tool list

### DIFF
--- a/apps/site/astro.config.mjs
+++ b/apps/site/astro.config.mjs
@@ -198,6 +198,7 @@ export default defineConfig({
             items: [
               { label: 'Playground', link: 'https://randsum.io' },
               { label: 'CLI', slug: 'tools/cli' },
+              { label: 'MCP Server', slug: 'tools/mcp' },
               { label: 'Discord Bot', slug: 'tools/discord-bot' },
               { label: 'Claude Plugin', slug: 'tools/claude-code-plugin' },
               { label: 'HTTP API & Schema', slug: 'tools/http-api' }

--- a/apps/site/public/llms.txt
+++ b/apps/site/public/llms.txt
@@ -7,6 +7,7 @@
 
 - @randsum/roller - Core dice engine with built-in RDN notation parser
 - @randsum/cli - Command-line dice roller (published npm CLI)
+- @randsum/mcp - Model Context Protocol stdio server exposing roll, validate, and roll_game tools to AI agents (bunx/npx @randsum/mcp)
 - @randsum/games - TTRPG game packages with subpath exports:
   - @randsum/games/fifth - D&D 5th Edition
   - @randsum/games/blades - Blades in the Dark
@@ -35,6 +36,11 @@ roll("g6")     // Geometric die
 roll("3DD6")   // Draw die
 roll("4d6Lx6") // Repeat operator
 roll("2d6+3[fire]") // Annotations
+
+## Web Surfaces
+
+- HTTP roll endpoint: POST https://randsum.dev/api/roll with JSON { "notation": "4d6L" }; returns { notation, total, rolls, description }. Runs the same roll() engine as @randsum/roller. CORS-enabled; GET returns the contract.
+- Hosted games meta-schema: https://randsum.dev/schemas/v1/randsum.json (JSON Schema for *.randsum.json game specs; reference it via a "$schema" key for editor autocompletion).
 
 ## Links
 

--- a/apps/site/src/content/docs/tools/mcp.mdx
+++ b/apps/site/src/content/docs/tools/mcp.mdx
@@ -1,0 +1,114 @@
+---
+title: MCP Server — RANDSUM for AI Agents
+description: Expose RANDSUM dice rolling to any MCP client. The @randsum/mcp stdio server gives AI agents roll, validate, and roll_game tools with seeded reproducibility.
+---
+
+import CodeExample from '../../../components/live-repl/CodeExample.astro'
+
+The **RANDSUM MCP server** (`@randsum/mcp`) is a
+[Model Context Protocol](https://modelcontextprotocol.io) stdio server that
+exposes the RANDSUM dice-rolling ecosystem to AI agents. It wraps
+`@randsum/roller` and `@randsum/games`, so an assistant can roll dice, validate
+notation, and roll for specific tabletop game systems.
+
+The server speaks MCP over stdio and ships as a CLI binary (`randsum-mcp`), so
+any MCP client can launch it with `bunx` or `npx` — no global install required.
+
+## Configuration
+
+The snippets below mirror
+[`packages/mcp/README.md`](https://github.com/RANDSUM/randsum/blob/main/packages/mcp/README.md),
+which is the source of truth for install and config.
+
+### Claude Code
+
+<CodeExample lang="bash" code={`claude mcp add randsum -- bunx -y @randsum/mcp`} />
+
+### Claude Desktop
+
+Add the server to `claude_desktop_config.json`:
+
+```json
+{
+  "mcpServers": {
+    "randsum": {
+      "command": "bunx",
+      "args": ["-y", "@randsum/mcp"]
+    }
+  }
+}
+```
+
+Any MCP client that can spawn a stdio server works — point it at the
+`randsum-mcp` binary (or `bunx @randsum/mcp` / `npx @randsum/mcp`).
+
+## Tools
+
+The server registers three tools:
+
+| Tool        | Input                                     | Returns                                                              |
+| ----------- | ----------------------------------------- | ------------------------------------------------------------------- |
+| `roll`      | `{ notation: string, seed?: number }`     | `total`, per-pool `pools`, and a human-readable `description`        |
+| `validate`  | `{ notation: string }`                    | `valid`, `description` (when valid), `suggestion`/`error` (when not) |
+| `roll_game` | `{ game: GameShortcode, params: object }` | game-interpreted `total`, `result`, `details`, and raw `rolls`      |
+
+### `roll`
+
+Rolls [RANDSUM dice notation](https://notation.randsum.dev) (e.g. `4d6L`,
+`2d20+5`, `1d100`). Pass an integer `seed` for a deterministic, reproducible
+roll. Invalid notation throws with a suggested fix.
+
+```json
+{ "notation": "4d6L", "seed": 42 }
+```
+
+The result carries the combined `total`, a `pools` array (one entry per dice
+pool, each with its own `rolls`, `total`, and `description`), and a top-level
+`description` string.
+
+### `validate`
+
+Checks whether a notation string is valid, returning a description when it is
+and a suggested fix when it is not (e.g. `d20` → `1d20`).
+
+```json
+{ "notation": "4d6L" }
+```
+
+### `roll_game`
+
+Rolls for one game system and interprets the dice per that game. `game` is one
+of `blades`, `daggerheart`, `fate`, `fifth`, `pbta`, `root-rpg`, or
+`salvageunion`. Only the `params` fields relevant to the chosen game are read;
+a required field missing for its game throws.
+
+| Game           | Relevant `params`                                       |
+| -------------- | ------------------------------------------------------- |
+| `blades`       | `rating`                                                |
+| `daggerheart`  | `modifier`, `amplifyHope`, `amplifyFear`, `rollingWith` |
+| `fate`         | `modifier`                                              |
+| `fifth`        | `modifier`, `rollingWith`, `crit`                       |
+| `pbta`         | `stat` (required), `forward`, `ongoing`, `rollingWith`  |
+| `root-rpg`     | `bonus` (required), `rollingWith`                       |
+| `salvageunion` | `tableName` (required)                                  |
+
+`rollingWith` is `"Advantage"` or `"Disadvantage"`.
+
+```json
+{ "game": "fifth", "params": { "modifier": 3, "rollingWith": "Advantage" } }
+```
+
+## Seeded reproducibility
+
+The `roll` tool accepts an optional integer `seed`. With a seed, the server uses
+a deterministic random number generator, so the same `notation` + `seed` always
+produces the same dice — ideal for tests, examples, and shareable results.
+Omit `seed` for a fresh random roll each call. (`validate` and `roll_game` do
+not take a seed.)
+
+## Links
+
+- [Source code](https://github.com/RANDSUM/randsum/tree/main/packages/mcp)
+- [README (install & config source of truth)](https://github.com/RANDSUM/randsum/blob/main/packages/mcp/README.md)
+- [RANDSUM notation reference](/notation/randsum-dice-notation/)
+- [Model Context Protocol](https://modelcontextprotocol.io)

--- a/apps/site/src/utils/packageData.ts
+++ b/apps/site/src/utils/packageData.ts
@@ -156,5 +156,16 @@ export const toolPackages: PackageInfo[] = [
     sourceUrl: 'https://github.com/RANDSUM/randsum/tree/main/apps/cli',
     category: 'tool',
     color: '#84cc16' // lime-500 — terminal/dev feel
+  },
+  {
+    id: 'mcp',
+    name: 'mcp',
+    displayName: 'MCP Server',
+    description:
+      'Model Context Protocol server exposing roll, validate, and roll_game tools to AI agents.',
+    npmPackage: '@randsum/mcp',
+    sourceUrl: 'https://github.com/RANDSUM/randsum/tree/main/packages/mcp',
+    category: 'tool',
+    color: '#E07A2F' // Claude orange
   }
 ]

--- a/llms.txt
+++ b/llms.txt
@@ -6,6 +6,7 @@
 
 - @randsum/roller - Core dice engine with built-in RDN notation parser
 - @randsum/cli - Command-line dice roller (published npm CLI)
+- @randsum/mcp - Model Context Protocol stdio server exposing roll, validate, and roll_game tools to AI agents (bunx/npx @randsum/mcp)
 - @randsum/games - TTRPG game packages with subpath exports:
   - @randsum/games/fifth - D&D 5th Edition
   - @randsum/games/blades - Blades in the Dark
@@ -34,6 +35,11 @@ roll("g6")     // Geometric die
 roll("3DD6")   // Draw die
 roll("4d6Lx6") // Repeat operator
 roll("2d6+3[fire]") // Annotations
+
+## Web Surfaces
+
+- HTTP roll endpoint: POST https://randsum.dev/api/roll with JSON { "notation": "4d6L" }; returns { notation, total, rolls, description }. Runs the same roll() engine as @randsum/roller. CORS-enabled; GET returns the contract.
+- Hosted games meta-schema: https://randsum.dev/schemas/v1/randsum.json (JSON Schema for *.randsum.json game specs; reference it via a "$schema" key for editor autocompletion).
 
 ## Links
 


### PR DESCRIPTION
Stitches site documentation for the two platform surfaces merged into main: the `@randsum/mcp` MCP server (PR #1152) and the randsum.dev web surfaces (hosted meta-schema + `POST /api/roll`, PR #1151).

## Changes

- **New `apps/site/src/content/docs/tools/mcp.mdx`** — Tools page modeled on `cli.mdx`. Covers what the server is, Claude Code (`claude mcp add`) and Claude Desktop config snippets (mirrored from `packages/mcp/README.md`, cited as source of truth), the `roll` / `validate` / `roll_game` tool reference with example calls, and a seeded-reproducibility note. Tool names and params cross-checked against `packages/mcp/src/tools/*`.
- **Sidebar** — added `MCP Server` entry to the Tools topic in `astro.config.mjs`, next to CLI.
- **Landing cards** — added an `@randsum/mcp` tool card to `src/utils/packageData.ts`, following how `cli` is represented.
- **llms.txt** — both the repo-root copy and the served `apps/site/public/llms.txt` (kept byte-identical apart from the sync header comment) now list `@randsum/mcp`, the hosted schema URL `https://randsum.dev/schemas/v1/randsum.json`, and the `POST /api/roll` endpoint.

## Verification

`bun run --filter @randsum/roller --filter @randsum/games build` then `bun run --filter @randsum/site check` (build + typecheck + format:check + lint + 48 tests) all pass. Pre-push hooks (build, codegen, conformance, tests, audit, SCA, knip, arch) passed.

No changeset (docs-only).

From the 2026-07-07 monorepo deep-dive audit (Wave 3).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019DMVgLnWbodhurNKcGM1oz