### PR TITLE
feat(mcp): add project-scoped netlify MCP server

### DIFF
--- a/.mcp.json
+++ b/.mcp.json
@@ -9,6 +9,10 @@
       "type": "http",
       "url": "https://api.githubcopilot.com/mcp/",
       "headersHelper": "$CLAUDE_PROJECT_DIR/scripts/mcp-1password-headers.sh"
+    },
+    "netlify": {
+      "type": "http",
+      "url": "https://netlify-mcp.netlify.app/mcp"
     }
   }
 }

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -172,10 +172,11 @@ Key syntax: `NdS` (basic), `+X`/`-X` (arithmetic), `L`/`H` (drop lowest/highest)
 `.mcp.json` (project-scoped, committed) declares the official MCP servers for
 this repo's deploy/host stack. Each maps to a real workspace target:
 
-| Server   | Transport | Backs                              | Auth                            |
-| -------- | --------- | ---------------------------------- | ------------------------------- |
-| `render` | http      | `apps/discord-bot` (Render worker) | 1Password PAT (`headersHelper`) |
-| `github` | http      | repo host (issues, PRs, releases)  | 1Password PAT (`headersHelper`) |
+| Server    | Transport | Backs                              | Auth                            |
+| --------- | --------- | ---------------------------------- | ------------------------------- |
+| `render`  | http      | `apps/discord-bot` (Render worker) | 1Password PAT (`headersHelper`) |
+| `github`  | http      | repo host (issues, PRs, releases)  | 1Password PAT (`headersHelper`) |
+| `netlify` | http      | `apps/site` / `apps/rdn` (Netlify) | OAuth — run `/mcp`              |
 
 Secrets are **never** committed. The `github` and `render` (http) servers
 resolve their fine-grained PATs at connect time via `scripts/mcp-1password-headers.sh`,
@@ -193,6 +194,8 @@ An already-exported env var wins over `op`, so CI / fresh checkouts without
 1Password can still authenticate by exporting `GITHUB_PAT` / `RENDER_API_KEY`
 before launch.
 
-Run `/mcp` in Claude Code to check connection status. Netlify is **not** a
-project-scoped server here — use the account-level claude.ai Netlify connector
-(already connected) for `apps/site` / `apps/rdn`.
+Run `/mcp` in Claude Code to check connection status. `netlify` authenticates
+via OAuth (run `/mcp` after first launch). The account-level claude.ai Netlify
+connector remains available in interactive sessions; the project-scoped server
+exists so headless/cron sessions — where account connectors are absent — can
+still manage the `apps/site` / `apps/rdn` deploys.


### PR DESCRIPTION
Recreates the still-relevant half of #1092 against current main: the official Netlify MCP server (`https://netlify-mcp.netlify.app/mcp`, OAuth via `/mcp`) as a project-scoped entry in `.mcp.json`, plus the CLAUDE.md MCP table/note update.

Rationale: the account-level claude.ai Netlify connector covers interactive sessions, but headless/cron agent sessions have no account connectors — the project-scoped server closes that gap for `apps/site`/`apps/rdn` deploy management. No secrets involved (OAuth), no headers-helper change. The supabase half of #1092 stays retired (its `apps/expo` rationale was removed in #1121).

**Review: approved** (self-authored two-file config/docs change; JSON validated, CLAUDE.md table matches .mcp.json).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019DMVgLnWbodhurNKcGM1oz