### PR TITLE
feat(site,rdn): add Ko-fi support button to public pages

### DIFF
--- a/apps/rdn/src/components/KofiButton.astro
+++ b/apps/rdn/src/components/KofiButton.astro
@@ -1,0 +1,78 @@
+---
+/**
+ * KofiButton — the official Ko-fi "Support me on Ko-fi" widget button.
+ *
+ * Renders an accessible fallback link to ko-fi.com up front, then upgrades it
+ * to Ko-fi's widget button once Widget_2.js loads. It uses the widget's
+ * `getHTML()` (not `draw()`, which relies on `document.write` and would blow
+ * away the page). If the script is blocked or fails, the plain link remains.
+ */
+interface Props {
+  /** Ko-fi page code — the `<code>` in `ko-fi.com/<code>`. */
+  code?: string
+  /** Button label. */
+  label?: string
+  /** Button accent colour (hex). */
+  color?: string
+  /** Optional class on the container element. */
+  class?: string
+}
+
+const {
+  code = 'C3Z82382ZC',
+  label = 'Support me on Ko-fi',
+  color = '#72a4f2',
+  class: className
+} = Astro.props
+---
+
+<span
+  class:list={['kofi-button', className]}
+  data-kofi-code={code}
+  data-kofi-label={label}
+  data-kofi-color={color}
+>
+  <a href={`https://ko-fi.com/${code}`} target="_blank" rel="noopener noreferrer">{label}</a>
+</span>
+
+<script>
+  const WIDGET_SRC = 'https://storage.ko-fi.com/cdn/widget/Widget_2.js'
+
+  declare global {
+    interface Window {
+      kofiwidget2?: {
+        init: (text: string, color: string, id: string) => void
+        getHTML: () => string
+      }
+    }
+  }
+
+  function renderAll(): void {
+    const widget = window.kofiwidget2
+    if (!widget) return
+    const placeholders = document.querySelectorAll<HTMLElement>('.kofi-button[data-kofi-code]')
+    placeholders.forEach((el) => {
+      const code = el.dataset.kofiCode
+      if (!code) return
+      const label = el.dataset.kofiLabel ?? 'Support me on Ko-fi'
+      const color = el.dataset.kofiColor ?? '#72a4f2'
+      widget.init(label, color, code)
+      el.innerHTML = widget.getHTML()
+      // Mark as upgraded so a second render pass skips it.
+      delete el.dataset.kofiCode
+    })
+  }
+
+  if (window.kofiwidget2) {
+    renderAll()
+  } else {
+    const existing = document.querySelector<HTMLScriptElement>(`script[src="${WIDGET_SRC}"]`)
+    const script = existing ?? document.createElement('script')
+    if (!existing) {
+      script.src = WIDGET_SRC
+      script.async = true
+      document.head.appendChild(script)
+    }
+    script.addEventListener('load', renderAll)
+  }
+</script>

--- a/apps/rdn/src/layouts/SpecLayout.astro
+++ b/apps/rdn/src/layouts/SpecLayout.astro
@@ -4,6 +4,7 @@ import VersionBanner from '../components/VersionBanner.astro'
 import SkipLink from '../components/SkipLink.astro'
 import ShareActions from '../components/ShareActions.astro'
 import MobileMenu from '../components/MobileMenu.astro'
+import KofiButton from '../components/KofiButton.astro'
 import '../styles/global.css'
 
 interface Heading {
@@ -93,6 +94,17 @@ const pageTitle = isLatest ? `${title}` : `${title} — ${version}`
       </aside>
     </div>
     {specMarkdown && <ShareActions specMarkdown={specMarkdown} specUrl={specUrl} />}
+    <footer class="spec-footer">
+      <KofiButton />
+    </footer>
+    <style>
+      .spec-footer {
+        display: flex;
+        justify-content: center;
+        padding: 2rem 1rem 3rem;
+        border-top: 1px solid var(--border);
+      }
+    </style>
     <script>
       const toggle = document.querySelector('[data-theme-toggle]')
       if (toggle) {

--- a/apps/site/astro.config.mjs
+++ b/apps/site/astro.config.mjs
@@ -101,7 +101,8 @@ export default defineConfig({
         Head: './src/components/Head.astro',
         Header: './src/components/Header.astro',
         SiteTitle: './src/components/SiteTitle.astro',
-        ThemeSelect: './src/components/ThemeSelect.astro'
+        ThemeSelect: './src/components/ThemeSelect.astro',
+        Footer: './src/components/Footer.astro'
       },
       plugins: [
         starlightPageActions({

--- a/apps/site/src/components/Footer.astro
+++ b/apps/site/src/components/Footer.astro
@@ -1,0 +1,28 @@
+---
+import Default from '@astrojs/starlight/components/Footer.astro'
+import KofiButton from './KofiButton.astro'
+
+// Splash pages (the landing page) render their own LandingFooter, which carries
+// the Ko-fi button — so skip it here to avoid a duplicate.
+const isSplash = Astro.locals.starlightRoute.entry.data.template === 'splash'
+---
+
+<Default />
+
+{
+  !isSplash && (
+    <div class="kofi-footer not-content">
+      <KofiButton />
+    </div>
+  )
+}
+
+<style>
+  .kofi-footer {
+    display: flex;
+    justify-content: center;
+    margin-top: 2rem;
+    padding-top: 1.5rem;
+    border-top: 1px solid var(--sl-color-hairline);
+  }
+</style>

--- a/apps/site/src/components/KofiButton.astro
+++ b/apps/site/src/components/KofiButton.astro
@@ -1,0 +1,78 @@
+---
+/**
+ * KofiButton — the official Ko-fi "Support me on Ko-fi" widget button.
+ *
+ * Renders an accessible fallback link to ko-fi.com up front, then upgrades it
+ * to Ko-fi's widget button once Widget_2.js loads. It uses the widget's
+ * `getHTML()` (not `draw()`, which relies on `document.write` and would blow
+ * away the page). If the script is blocked or fails, the plain link remains.
+ */
+interface Props {
+  /** Ko-fi page code — the `<code>` in `ko-fi.com/<code>`. */
+  code?: string
+  /** Button label. */
+  label?: string
+  /** Button accent colour (hex). */
+  color?: string
+  /** Optional class on the container element. */
+  class?: string
+}
+
+const {
+  code = 'C3Z82382ZC',
+  label = 'Support me on Ko-fi',
+  color = '#72a4f2',
+  class: className
+} = Astro.props
+---
+
+<span
+  class:list={['kofi-button', className]}
+  data-kofi-code={code}
+  data-kofi-label={label}
+  data-kofi-color={color}
+>
+  <a href={`https://ko-fi.com/${code}`} target="_blank" rel="noopener noreferrer">{label}</a>
+</span>
+
+<script>
+  const WIDGET_SRC = 'https://storage.ko-fi.com/cdn/widget/Widget_2.js'
+
+  declare global {
+    interface Window {
+      kofiwidget2?: {
+        init: (text: string, color: string, id: string) => void
+        getHTML: () => string
+      }
+    }
+  }
+
+  function renderAll(): void {
+    const widget = window.kofiwidget2
+    if (!widget) return
+    const placeholders = document.querySelectorAll<HTMLElement>('.kofi-button[data-kofi-code]')
+    placeholders.forEach((el) => {
+      const code = el.dataset.kofiCode
+      if (!code) return
+      const label = el.dataset.kofiLabel ?? 'Support me on Ko-fi'
+      const color = el.dataset.kofiColor ?? '#72a4f2'
+      widget.init(label, color, code)
+      el.innerHTML = widget.getHTML()
+      // Mark as upgraded so a second render pass skips it.
+      delete el.dataset.kofiCode
+    })
+  }
+
+  if (window.kofiwidget2) {
+    renderAll()
+  } else {
+    const existing = document.querySelector<HTMLScriptElement>(`script[src="${WIDGET_SRC}"]`)
+    const script = existing ?? document.createElement('script')
+    if (!existing) {
+      script.src = WIDGET_SRC
+      script.async = true
+      document.head.appendChild(script)
+    }
+    script.addEventListener('load', renderAll)
+  }
+</script>

--- a/apps/site/src/components/landing/LandingFooter.astro
+++ b/apps/site/src/components/landing/LandingFooter.astro
@@ -1,9 +1,12 @@
 ---
-
+import KofiButton from '../KofiButton.astro'
 ---
 
 <footer class="landing-footer not-content">
   <div class="section-inner">
+    <div class="footer-support">
+      <KofiButton />
+    </div>
     <div class="footer-links">
       <div class="footer-col">
         <h4>Documentation</h4>
@@ -49,3 +52,13 @@
     </div>
   </div>
 </footer>
+
+<style>
+  .footer-support {
+    display: flex;
+    justify-content: center;
+    margin-bottom: 2rem;
+    padding-bottom: 2rem;
+    border-bottom: 1px solid var(--sl-color-hairline, rgba(255, 255, 255, 0.1));
+  }
+</style>

--- a/apps/site/src/pages/discord.astro
+++ b/apps/site/src/pages/discord.astro
@@ -1,5 +1,6 @@
 ---
 import StarlightPage from '@astrojs/starlight/components/StarlightPage.astro'
+import KofiButton from '../components/KofiButton.astro'
 
 const OAUTH_URL =
   'https://discord.com/oauth2/authorize?client_id=1290434147159904276&permissions=274877906944&scope=bot%20applications.commands'
@@ -271,6 +272,9 @@ const commands = [
             Add to Discord
           </a>
           <a href="/tools/discord-bot/" class="btn btn-secondary"> Full Documentation </a>
+        </div>
+        <div class="cta-support">
+          <KofiButton />
         </div>
       </div>
     </section>
@@ -605,6 +609,12 @@ const commands = [
     gap: 0.75rem;
     justify-content: center;
     flex-wrap: wrap;
+  }
+
+  .cta-support {
+    display: flex;
+    justify-content: center;
+    margin-top: 1.75rem;
   }
 
   /* ---- Responsive ---- */


### PR DESCRIPTION
Adds a **"Support me on Ko-fi"** button (`ko-fi.com/C3Z82382ZC`) to every public page of **randsum.dev** and **notation.randsum.dev**.

## What

A shared `KofiButton.astro` (one per app) renders an accessible fallback `<a>` link and progressively upgrades it to Ko-fi's official widget via `Widget_2.js`'s `getHTML()` — **not** `draw()`, which uses `document.write` and would blow away the page. If the script is blocked or fails, the plain link remains (progressive enhancement).

Button code/label/color mirror the SU-SRD `KofiButton` (`C3Z82382ZC`, "Support me on Ko-fi", `#72a4f2`).

## Placement (exactly one button per page)

**`apps/site` (randsum.dev, Starlight):**
- Starlight `Footer` component override → all docs pages
- `LandingFooter.astro` → home page (splash template)
- `discord.astro` CTA → Discord bot landing
- The Footer override is suppressed on `splash` pages so the home page's `LandingFooter` button isn't duplicated.

**`apps/rdn` (notation.randsum.dev):**
- `SpecLayout.astro` footer → every spec page

## Notes

- No CSP header exists in either app's `netlify.toml`, so nothing to update there (unlike SU-SRD, which has a strict CSP).
- Verified: `typecheck` + `build` pass for both apps; built HTML contains exactly one Ko-fi placeholder per page with the correct fallback link, data attributes, and bundled widget script.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XK9FSMgz3LDCQPQ4Xd81gc