### PR TITLE
fix(publish): make unresolved workspace: refs impossible to publish + republish broken legacy 1.x games

### DIFF
--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -48,7 +48,7 @@
     "lint": "biome lint .",
     "format": "biome format --write .",
     "format:check": "biome format .",
-    "prepublishOnly": "bun run build",
+    "prepublishOnly": "bun ../../scripts/ensure-bun-publish.ts && bun run build",
     "typecheck": "tsc --noEmit",
     "check": "bun run build && bun run typecheck && bun run format:check && bun run lint && bun run test"
   },

--- a/packages/games/package.json
+++ b/packages/games/package.json
@@ -117,7 +117,7 @@
     "typescript": "catalog:"
   },
   "scripts": {
-    "prepublishOnly": "bun run build",
+    "prepublishOnly": "bun ../../scripts/ensure-bun-publish.ts && bun run build",
     "build": "bunup",
     "gen": "bun run codegen.ts",
     "gen:check": "bun run codegen.ts --check",

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -55,7 +55,7 @@
     "lint": "biome lint .",
     "format": "biome format --write .",
     "format:check": "biome format .",
-    "prepublishOnly": "bun run build",
+    "prepublishOnly": "bun ../../scripts/ensure-bun-publish.ts && bun run build",
     "typecheck": "tsc --noEmit",
     "check": "bun run build && bun run typecheck && bun run format:check && bun run lint && bun run test"
   },

--- a/packages/roller/package.json
+++ b/packages/roller/package.json
@@ -105,7 +105,7 @@
   },
   "scripts": {
     "dev": "bunup --watch",
-    "prepublishOnly": "bun run build",
+    "prepublishOnly": "bun ../../scripts/ensure-bun-publish.ts && bun run build",
     "build": "bunup",
     "test": "bun test",
     "test:coverage": "bun test --coverage --coverage-reporter=lcov --coverage-dir=./coverage",

--- a/scripts/ensure-bun-publish.ts
+++ b/scripts/ensure-bun-publish.ts
@@ -1,0 +1,34 @@
+#!/usr/bin/env bun
+
+/**
+ * Publish-client guard — enforce "always publish through bun so workspace: resolves".
+ *
+ * The bun/pnpm `workspace:` protocol is a dev-time reference that must be resolved
+ * to a real semver range at pack time. `bun` (via `bun pm pack` / `bun publish`)
+ * does this; a raw `npm publish` does NOT — it ships the literal `workspace:~`,
+ * producing a package that is completely uninstallable:
+ *
+ *     npm error code EUNSUPPORTEDPROTOCOL
+ *     npm error Unsupported URL Type "workspace:": workspace:~
+ *
+ * That is exactly how the legacy standalone game packages (@randsum/salvageunion,
+ * daggerheart, blades, fifth, root-rpg, pbta) were broken. This runs as each
+ * publishable package's `prepublishOnly` hook.
+ *
+ * npm runs `prepublishOnly` on `npm publish <dir>` but NOT on `npm publish <tarball>`,
+ * and the sanctioned path (scripts/publish.ts) publishes an already-resolved tarball —
+ * so this guard never trips the sanctioned path, only a direct `npm publish` footgun.
+ * Publishing via `bun run publish` or a direct `bun publish` passes.
+ */
+
+const userAgent = process.env['npm_config_user_agent'] ?? ''
+
+if (!userAgent.startsWith('bun')) {
+  console.error(
+    `Refusing to publish via ${userAgent.split('/')[0] || 'a non-bun client'}: it does not ` +
+      'resolve the `workspace:` protocol, so the published package would be uninstallable ' +
+      '(npm EUNSUPPORTEDPROTOCOL).\n' +
+      'Publish with `bun run publish` (from the repo root) or a direct `bun publish`.'
+  )
+  process.exit(1)
+}

--- a/scripts/publish.ts
+++ b/scripts/publish.ts
@@ -63,6 +63,48 @@ async function getPublishablePackages(): Promise<{ name: string; dir: string }[]
  * or run prepublishOnly, so we flip the field only for the pack and restore it immediately after —
  * the tarball ships the already-built healthy dist with a tree-shakeable manifest. See ADR-018.
  */
+/**
+ * Guard: assert a packed tarball's manifest carries no unresolved `workspace:` protocol.
+ *
+ * The `workspace:` protocol is a bun/pnpm dev-time reference that MUST be resolved to a real
+ * semver range at pack time — `bun pm pack` does this. If a tarball ever ships `workspace:~`
+ * to the registry, `npm install` of that package hard-fails with
+ * `EUNSUPPORTEDPROTOCOL Unsupported URL Type "workspace:"`, making it completely uninstallable.
+ *
+ * This exact failure shipped in the legacy standalone game packages (@randsum/salvageunion,
+ * daggerheart, blades, fifth, root-rpg, pbta) when they were published with a raw `npm publish`
+ * (which does NOT resolve `workspace:`) before this script existed. This guard makes that class
+ * of breakage impossible to publish again, independent of which tool packed the tarball.
+ */
+async function assertNoWorkspaceProtocol(tgzPath: string, name: string): Promise<void> {
+  const manifestText = await $`tar -xzOf ${tgzPath} package/package.json`.text()
+  const manifest = JSON.parse(manifestText) as Record<string, unknown>
+  const depFields = [
+    'dependencies',
+    'peerDependencies',
+    'optionalDependencies',
+    'devDependencies'
+  ] as const
+  const offenders: string[] = []
+  for (const field of depFields) {
+    const deps = manifest[field]
+    if (deps && typeof deps === 'object') {
+      for (const [dep, range] of Object.entries(deps as Record<string, unknown>)) {
+        if (typeof range === 'string' && range.startsWith('workspace:')) {
+          offenders.push(`${field}.${dep} = ${range}`)
+        }
+      }
+    }
+  }
+  if (offenders.length > 0) {
+    throw new Error(
+      `${name} tarball still contains unresolved workspace: protocol — this would be ` +
+        `uninstallable via npm (EUNSUPPORTEDPROTOCOL). Refusing to publish.\n` +
+        offenders.map(o => `    ${o}`).join('\n')
+    )
+  }
+}
+
 async function packRollerWithSideEffectsFalse(dir: string): Promise<string> {
   const pkgPath = join(dir, 'package.json')
   const original = await Bun.file(pkgPath).text()
@@ -111,6 +153,10 @@ for (const { name, dir } of packages) {
     if (tgzMatch) {
       console.log(tgzMatch[0])
     }
+
+    // Refuse to publish a tarball that still carries an unresolved workspace: protocol —
+    // it would be uninstallable via npm. See assertNoWorkspaceProtocol for the incident.
+    await assertNoWorkspaceProtocol(tgzPath, name)
 
     const npmArgs = ['publish', tgzPath, '--access=public']
     // Provenance requires an OIDC-capable CI; skip it for local --otp publishes.

--- a/scripts/publish.ts
+++ b/scripts/publish.ts
@@ -54,16 +54,6 @@ async function getPublishablePackages(): Promise<{ name: string; dir: string }[]
 }
 
 /**
- * Pack @randsum/roller with `sideEffects: false` injected into the published manifest.
- *
- * The in-repo package.json keeps `sideEffects: true` because bunup's self-DCE breaks roller's
- * dist when it builds with `false`, AND the cli bundles roller from source (noExternal) and reads
- * that field. But consumers installing the published package should be able to tree-shake the
- * narrow surfaces (e.g. `isDiceNotation`) out of the engine. `bun pm pack` does NOT rebuild dist
- * or run prepublishOnly, so we flip the field only for the pack and restore it immediately after —
- * the tarball ships the already-built healthy dist with a tree-shakeable manifest. See ADR-018.
- */
-/**
  * Guard: assert a packed tarball's manifest carries no unresolved `workspace:` protocol.
  *
  * The `workspace:` protocol is a bun/pnpm dev-time reference that MUST be resolved to a real
@@ -105,6 +95,16 @@ async function assertNoWorkspaceProtocol(tgzPath: string, name: string): Promise
   }
 }
 
+/**
+ * Pack @randsum/roller with `sideEffects: false` injected into the published manifest.
+ *
+ * The in-repo package.json keeps `sideEffects: true` because bunup's self-DCE breaks roller's
+ * dist when it builds with `false`, AND the cli bundles roller from source (noExternal) and reads
+ * that field. But consumers installing the published package should be able to tree-shake the
+ * narrow surfaces (e.g. `isDiceNotation`) out of the engine. `bun pm pack` does NOT rebuild dist
+ * or run prepublishOnly, so we flip the field only for the pack and restore it immediately after —
+ * the tarball ships the already-built healthy dist with a tree-shakeable manifest. See ADR-018.
+ */
 async function packRollerWithSideEffectsFalse(dir: string): Promise<string> {
   const pkgPath = join(dir, 'package.json')
   const original = await Bun.file(pkgPath).text()

--- a/scripts/republish-legacy-1x.ts
+++ b/scripts/republish-legacy-1x.ts
@@ -1,0 +1,212 @@
+#!/usr/bin/env bun
+
+/**
+ * One-off remediation: republish the broken legacy standalone game packages.
+ *
+ * INCIDENT
+ * --------
+ * Six legacy standalone game packages had their `latest` dist-tag pointing at a
+ * version that shipped a literal, unresolved `"@randsum/roller": "workspace:~"`
+ * dependency. Those versions were published with a raw `npm publish` (before
+ * scripts/publish.ts existed) — and `npm publish` does NOT resolve the bun/pnpm
+ * `workspace:` protocol the way `bun pm pack` does. The result: every one of
+ * these packages is completely uninstallable —
+ *
+ *     npm error code EUNSUPPORTEDPROTOCOL
+ *     npm error Unsupported URL Type "workspace:": workspace:~
+ *
+ * These packages are already deprecated in favour of `@randsum/games/<game>`
+ * subpath exports, but deprecation is only a warning: npm still resolves the
+ * dependency tree and hard-fails, so consumers cannot even install them to see
+ * the redirect.
+ *
+ * FIX
+ * ---
+ * Republish each with a patch bump and the `workspace:~` reference resolved to
+ * `~1.1.2` — the last @randsum/roller 1.1.x, which is the roller these 1.x game
+ * builds were compiled against. (roller 1.2.3 removed `createGameRoll` /
+ * `createMultiRollGameRoll`, which four of these packages import, so pinning to
+ * roller 1.3.0 fixes install but breaks import — hence ~1.1.2, verified to both
+ * install and import for all six.) The deprecation notice is re-applied to the
+ * new version so the redirect is preserved.
+ *
+ * This is a MANUAL, one-time op — these packages are not in the workspace, so
+ * the changesets/Trusted-Publishing pipeline never touches them. Publishing is
+ * 2FA-gated (auth-and-writes), so an OTP is required.
+ *
+ * USAGE
+ * -----
+ *   bun scripts/republish-legacy-1x.ts --dry-run          # build + verify only, no publish
+ *   bun scripts/republish-legacy-1x.ts --otp=123456       # actually publish + re-deprecate
+ *
+ * Prevention against a recurrence of this exact class of bug lives in
+ * scripts/publish.ts (assertNoWorkspaceProtocol).
+ */
+
+import { join } from 'node:path'
+import { mkdtempSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { $ } from 'bun'
+
+/** The roller range these 1.x game builds were compiled against. */
+const ROLLER_PIN = '~1.1.2'
+
+interface Target {
+  readonly name: string
+  /** Broken version currently tagged `latest`. */
+  readonly broken: string
+  /** Patched version to publish. */
+  readonly next: string
+  /** Deprecation message to re-apply to the new version. */
+  readonly deprecate: string
+}
+
+const TARGETS: readonly Target[] = [
+  {
+    name: '@randsum/salvageunion',
+    broken: '1.0.0',
+    next: '1.0.1',
+    deprecate: 'Use @randsum/games/salvageunion instead. See https://randsum.dev'
+  },
+  {
+    name: '@randsum/daggerheart',
+    broken: '1.1.0',
+    next: '1.1.1',
+    deprecate: 'Use @randsum/games/daggerheart instead. See https://randsum.dev'
+  },
+  {
+    name: '@randsum/blades',
+    broken: '1.1.0',
+    next: '1.1.1',
+    deprecate: 'Use @randsum/games/blades instead. See https://randsum.dev'
+  },
+  {
+    name: '@randsum/fifth',
+    broken: '1.1.0',
+    next: '1.1.1',
+    deprecate: 'Use @randsum/games/fifth instead. See https://randsum.dev'
+  },
+  {
+    name: '@randsum/root-rpg',
+    broken: '1.0.0',
+    next: '1.0.1',
+    deprecate: 'Use @randsum/games/root-rpg instead. See https://randsum.dev'
+  },
+  {
+    name: '@randsum/pbta',
+    broken: '1.0.0',
+    next: '1.0.1',
+    deprecate: 'Use @randsum/games/pbta instead. See https://randsum.dev'
+  }
+] as const
+
+const extraArgs = process.argv.slice(2)
+const dryRun = extraArgs.includes('--dry-run')
+const otpArg = extraArgs.find(a => a.startsWith('--otp='))
+
+if (!dryRun && !otpArg) {
+  console.error(
+    'Refusing to publish without an OTP. Pass --otp=<code> (2FA is auth-and-writes),\n' +
+      'or run with --dry-run to build and verify the corrected tarballs first.'
+  )
+  process.exit(1)
+}
+
+/**
+ * Repack a published version with `version` bumped and every `workspace:` dep resolved.
+ * Returns the path to the corrected tarball.
+ */
+async function buildCorrectedTarball(target: Target, workdir: string): Promise<string> {
+  await $`npm pack ${target.name}@${target.broken}`.cwd(workdir).quiet()
+  const original = (await Array.fromAsync(new Bun.Glob('*.tgz').scan(workdir)))[0]
+  if (!original) {
+    throw new Error(`npm pack produced no tarball for ${target.name}@${target.broken}`)
+  }
+  await $`tar -xzf ${original}`.cwd(workdir).quiet()
+
+  const pkgPath = join(workdir, 'package', 'package.json')
+  const manifest = (await Bun.file(pkgPath).json()) as {
+    version: string
+    dependencies?: Record<string, string>
+  }
+  const deps = manifest.dependencies ?? {}
+  const workspaceDeps = Object.entries(deps).filter(([, range]) => range.startsWith('workspace:'))
+  if (workspaceDeps.length === 0) {
+    throw new Error(`${target.name}@${target.broken} had no workspace: dep — unexpected, aborting`)
+  }
+  const resolvedDeps = Object.fromEntries(
+    Object.entries(deps).map(([dep, range]) => {
+      if (!range.startsWith('workspace:')) {
+        return [dep, range]
+      }
+      if (dep !== '@randsum/roller') {
+        throw new Error(
+          `Unexpected non-roller workspace: dep ${dep} in ${target.name} — no pin known`
+        )
+      }
+      return [dep, ROLLER_PIN]
+    })
+  )
+  const nextManifest = { ...manifest, version: target.next, dependencies: resolvedDeps }
+  await Bun.write(pkgPath, JSON.stringify(nextManifest, null, 2) + '\n')
+
+  const packDir = join(workdir, 'package')
+  const packOut = await $`npm pack`.cwd(packDir).text()
+  const lines = packOut.trim().split('\n')
+  const fixed = lines[lines.length - 1]
+  if (!fixed) {
+    throw new Error(`npm pack produced no tarball for ${target.name}@${target.next}`)
+  }
+  return join(packDir, fixed)
+}
+
+/**
+ * Install a corrected tarball into a throwaway project and import it, proving it
+ * both resolves (no EUNSUPPORTEDPROTOCOL) and loads (roller API present).
+ */
+async function verifyTarball(target: Target, tgzPath: string): Promise<void> {
+  const consumer = mkdtempSync(join(tmpdir(), 'randsum-verify-'))
+  await $`npm init -y`.cwd(consumer).quiet()
+  await $`npm install ${tgzPath}`.cwd(consumer).quiet()
+  await $`node --input-type=module -e ${`await import(${JSON.stringify(target.name)})`}`
+    .cwd(consumer)
+    .quiet()
+}
+
+const failed: string[] = []
+for (const target of TARGETS) {
+  console.log(`\n--- ${target.name} ${target.broken} -> ${target.next} ---`)
+  const workdir = mkdtempSync(join(tmpdir(), 'randsum-republish-'))
+  try {
+    const tgzPath = await buildCorrectedTarball(target, workdir)
+    await verifyTarball(target, tgzPath)
+    console.log(`  built + verified (installs & imports against roller ${ROLLER_PIN})`)
+
+    if (dryRun) {
+      console.log('  dry run — not publishing')
+      continue
+    }
+
+    // otpArg is guaranteed present here: the top-level guard exits unless dryRun || otpArg.
+    const otp = otpArg ?? ''
+    const result = await $`npm publish ${tgzPath} --access=public ${otp}`.nothrow()
+    if (result.exitCode !== 0) {
+      console.error(result.stderr.toString())
+      failed.push(target.name)
+      continue
+    }
+    console.log(`  published ${target.name}@${target.next}`)
+
+    await $`npm deprecate ${`${target.name}@${target.next}`} ${target.deprecate} ${otp}`.quiet()
+    console.log('  re-applied deprecation notice')
+  } catch (e) {
+    console.error(String(e))
+    failed.push(target.name)
+  }
+}
+
+if (failed.length > 0) {
+  console.error(`\nFailed: ${failed.join(', ')}`)
+  process.exit(1)
+}
+console.log(`\nAll ${TARGETS.length} legacy packages ${dryRun ? 'verified' : 'republished'}.`)


### PR DESCRIPTION
## The break

`npm install @randsum/salvageunion` (and 5 sibling game packages) hard-fails:

```
npm error code EUNSUPPORTEDPROTOCOL
npm error Unsupported URL Type "workspace:": workspace:~
```

Six legacy standalone game packages have their `latest` dist-tag pointing at a version that shipped a **literal, unresolved `"@randsum/roller": "workspace:~"`** dependency:

| Package | Broken `latest` | → republish as |
|---|---|---|
| `@randsum/salvageunion` | 1.0.0 | 1.0.1 |
| `@randsum/daggerheart` | 1.1.0 | 1.1.1 |
| `@randsum/blades` | 1.1.0 | 1.1.1 |
| `@randsum/fifth` | 1.1.0 | 1.1.1 |
| `@randsum/root-rpg` | 1.0.0 | 1.0.1 |
| `@randsum/pbta` | 1.0.0 | 1.0.1 |

These are already deprecated in favour of `@randsum/games/<game>` subpaths, but **deprecation is only a warning** — npm still resolves the dependency tree and hard-fails, so consumers can't even install them to see the redirect.

## Root cause

They were published with a raw `npm publish` (before `scripts/publish.ts` existed). `npm publish` does **not** resolve the bun/pnpm `workspace:` protocol the way `bun` does, so it shipped the literal string to the registry.

## Prevention — two layers, so `workspace:` can never escape again

1. **`scripts/ensure-bun-publish.ts`** — wired into every publishable package's `prepublishOnly` hook (roller, games, mcp, cli). Refuses any non-bun publish client: a raw `npm publish <dir>` is blocked; `bun run publish` / `bun publish` pass. (npm runs `prepublishOnly` on `publish <dir>` but *not* on `publish <tarball>`, so the sanctioned path is unaffected.)
2. **`scripts/publish.ts`** — now inspects every packed tarball's manifest and refuses to publish if any dependency still carries the `workspace:` protocol. Tool-agnostic backstop, caught pre-publish.

## Remediation

**`scripts/republish-legacy-1x.ts`** rebuilds each broken package with a patch bump and the workspace ref resolved to **`~1.1.2`** — the roller these 1.x game builds compile against. (roller 1.2.3 removed `createGameRoll` / `createMultiRollGameRoll`, which four of these packages import, so pinning to roller 1.3.0 fixes install but *breaks import* — hence `~1.1.2`.)

Verified end-to-end via `--dry-run`: all six now **install and import** cleanly (`salvageunion.rollTable`, `daggerheart.roll('2d12')`, etc. produce real rolls).

⚠️ **Publishing the fixed versions is a manual, 2FA-gated step** (these packages aren't in the workspace, so the changesets/Trusted-Publishing pipeline never touches them):

```bash
bun scripts/republish-legacy-1x.ts --dry-run       # verify (no publish)
bun scripts/republish-legacy-1x.ts --otp=<code>    # publish + re-deprecate
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)