### PR TITLE
docs(site,rdn): record why TypeScript stays at 6.0.3 in the Astro apps

### DIFF
--- a/apps/rdn/CLAUDE.md
+++ b/apps/rdn/CLAUDE.md
@@ -102,6 +102,14 @@ keeping the published JSON in sync with the source.
   imports `MODIFIER_DOCS` / `DICE_DOCS` from `@randsum/roller/docs` to auto-generate
   the modifier reference appendix.
 - No client-side framework — interactivity is vanilla TS in Astro `<script>` blocks.
+- **`typescript` is pinned to `6.0.3` here, deliberately — do NOT move it to `catalog:`.**
+  The rest of the workspace is on TypeScript 7.0.2 via the root `catalog`, and this app
+  and `apps/site` are the only holdouts. They are blocked upstream, not by neglect:
+  `@astrojs/check` declares `peerDependencies: { typescript: "^5.0.0 || ^6.0.0" }` as of
+  its latest release (0.9.10), and under TS 7 `astro check` dies before checking anything
+  with `Cannot read properties of undefined (reading 'fileExists')` in
+  `@astrojs/language-server`'s `getTsconfig`. Revisit when `@astrojs/check` ships a
+  release whose peer range admits TypeScript 7.
 - Private app, never published to npm.
 - Deployed to Netlify (see `netlify.toml`).
 - Fonts: Inter (body) and JetBrains Mono (code/headings), via Astro's Google

--- a/apps/site/CLAUDE.md
+++ b/apps/site/CLAUDE.md
@@ -17,6 +17,15 @@ Private app, deploys to Netlify on push to `main`. Lives at `randsum.dev`.
   playground / notation components
 - Fonts (Inter, JetBrains Mono) via Astro's Google font provider
 
+> **`typescript` is pinned to `6.0.3` here, deliberately — do NOT move it to `catalog:`.**
+> The rest of the workspace is on TypeScript 7.0.2 via the root `catalog`; this app and
+> `apps/rdn` are the only holdouts, and they are blocked upstream rather than overlooked.
+> `@astrojs/check` declares `peerDependencies: { typescript: "^5.0.0 || ^6.0.0" }` as of its
+> latest release (0.9.10), and under TS 7 `astro check` dies before checking anything with
+> `Cannot read properties of undefined (reading 'fileExists')` in `@astrojs/language-server`'s
+> `getTsconfig`. Revisit when `@astrojs/check` ships a release whose peer range admits
+> TypeScript 7.
+
 ## Content Structure
 
 Docs live in `src/content/docs/` as `.mdx` files; Starlight auto-routes them.


### PR DESCRIPTION
## Summary

Records why `apps/site` and `apps/rdn` pin `typescript` to `6.0.3` while the rest of the workspace is on 7.0.2. Docs only — no dependency, lockfile, or code change.

## The finding

**TypeScript 7.0.2 is already adopted everywhere it can be.** The root `catalog` pins it, and every workspace package either references `catalog:` or inherits the root: `packages/roller`, `packages/games`, `packages/dice-ui`, `packages/mcp`, `apps/cli`, `apps/discord-bot`.

`apps/site` and `apps/rdn` are the only holdouts, and the pin is **load-bearing, not drift**. I tried to remove it and verified in both directions:

- Pointing either app at `catalog:` (7.0.2) makes `astro check` fail before it checks anything:
  ```
  Cannot read properties of undefined (reading 'fileExists')
    at AstroCheck.getTsconfig (@astrojs/language-server/dist/check.js:162)
  ```
- Reverting to `6.0.3` restores a clean run — **0 errors, 0 warnings, 0 hints** in both apps.
- `@astrojs/check`'s **latest** release (0.9.10, one ahead of the pinned 0.9.9) still declares:
  ```json
  "peerDependencies": { "typescript": "^5.0.0 || ^6.0.0" }
  ```

So no published `@astrojs/check` admits TypeScript 7. There is no version bump that fixes this — it needs an upstream release.

## Why this needed writing down

`package.json` cannot carry a comment, so the constraint had nowhere to live. That is why it reads as neglect, why Dependabot kept re-proposing the bump (#1178, now closed), and why it is the natural thing for someone to "tidy up" — as I nearly did.

Both app `CLAUDE.md` files now state the pin, say explicitly **not** to move it to `catalog:`, give the exact failure so it is recognisable, and name the condition for revisiting: a `@astrojs/check` release whose peer range admits TypeScript 7.

## Related

- #1178 — the recurring Dependabot bump, closed with this explanation.
- #1159 — "Upgrade to TypeScript 7". This PR documents the remaining blocker on that issue: the two Astro apps cannot follow until `@astrojs/check` moves.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MRVtW9UjU8AA3sRiuBQYqL
