### PR TITLE
chore(ci): rename the aggregate gate display name to "CI Success"

### DIFF
--- a/.dependency-cruiser.cjs
+++ b/.dependency-cruiser.cjs
@@ -5,7 +5,7 @@
 //   2. no game subpath imports another game subpath
 //   3. no consumer reaches into @randsum/*/src or @randsum/*/dist
 //
-// Run:  bun run arch:check   (wired into lefthook pre-push and the CI Gate)
+// Run:  bun run arch:check   (wired into lefthook pre-push and the CI Success gate)
 
 /** @type {import('dependency-cruiser').IConfiguration} */
 module.exports = {

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -117,8 +117,8 @@ jobs:
     if: fromJSON(needs.changes.outputs.matrix).include[0] != null
     runs-on: ubuntu-latest
     strategy:
-      # Run every package leg even if a sibling fails, so the CI Gate sees each
-      # package's real result instead of a fail-fast cancellation.
+      # Run every package leg even if a sibling fails, so the CI Success gate
+      # sees each package's real result instead of a fail-fast cancellation.
       fail-fast: false
       matrix: ${{ fromJSON(needs.changes.outputs.matrix) }}
     steps:
@@ -170,7 +170,7 @@ jobs:
         run: bun run --filter "@randsum/$PKG" size
 
   ci-aggregator:
-    # Guard against a job silently opting out of the CI Gate. `ci-gate`'s `needs:`
+    # Guard against a job silently opting out of the gate. `ci-gate`'s `needs:`
     # list is hand-maintained, and a job missing from it still runs, still goes
     # red, and still cannot fail the only required status check — the gate stops
     # gating with no symptom. This job diffs the two lists mechanically, and is
@@ -186,7 +186,8 @@ jobs:
     # Guard against a package silently opting out of the standard script set.
     # `bun run --filter '*' <script>` skips packages that lack the target script,
     # which is how dice-ui escaped linting for months (audit Wave 3). This job
-    # feeds the CI Gate so the escape hatch cannot be bypassed with --no-verify.
+    # feeds the CI Success gate so the escape hatch cannot be bypassed with
+    # --no-verify.
     name: workspace-scripts
     runs-on: ubuntu-latest
     steps:
@@ -347,9 +348,9 @@ jobs:
     # transitives. Report-only: `bun audit` above is the blocking advisory gate,
     # while this job deliberately reports what that gate does not cover —
     # anything below `high`. `continue-on-error: true` plus its absence from the
-    # `CI Gate` needs list is what keeps those findings informative rather than
-    # blocking. It is currently green (the two Medium and one Low it used to
-    # report — @astrojs/netlify, @hono/node-server, astro — all had published
+    # `CI Success` needs list is what keeps those findings informative rather
+    # than blocking. It is currently green (the two Medium and one Low it used
+    # to report — @astrojs/netlify, @hono/node-server, astro — all had published
     # fixes and were bumped), so a new finding here is genuinely new. See
     # osv-scanner.toml for the per-advisory reasoning.
     name: sca
@@ -370,7 +371,7 @@ jobs:
             ./
 
   ci-gate:
-    name: CI Gate
+    name: CI Success
     if: always()
     # `package` is the consolidated matrix job: its single `result` aggregates
     # every leg (roller, games, cli, mcp, discord-bot, site, rdn, dice-ui) — if

--- a/.github/workflows/workflow-lint.yml
+++ b/.github/workflows/workflow-lint.yml
@@ -1,10 +1,10 @@
 name: Workflow Lint
 
 # Static analysis of the GitHub Actions workflows themselves (audit CI-tooling).
-# Not a required check / not wired into the CI Gate — it's an advisory hardening
-# pass. actionlint validates workflow syntax + shellcheck's the `run:` scripts;
-# zizmor audits for CI security smells. Both actions are SHA-pinned like every
-# other action in this repo.
+# Not a required check / not wired into the CI Success gate — it's an advisory
+# hardening pass. actionlint validates workflow syntax + shellcheck's the `run:`
+# scripts; zizmor audits for CI security smells. Both actions are SHA-pinned like
+# every other action in this repo.
 on:
   push:
     branches: [main]

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -76,6 +76,7 @@ pre-push:
     arch-check:
       # Cycle + boundary invariants (audit X7b / architecture R2+R3): no circular
       # deps, no game-to-game import, no @randsum/*/src or /dist reach-in. Also runs
-      # in CI feeding the CI Gate so it cannot be bypassed with --no-verify.
+      # in CI feeding the CI Success gate so it cannot be bypassed with
+      # --no-verify.
       run: bun run arch:check > /dev/null 2>&1
       priority: 2

--- a/osv-scanner.toml
+++ b/osv-scanner.toml
@@ -16,7 +16,7 @@
 #
 # NOTE ON THE TWO GATES. `bun audit --audit-level=high` is the blocking gate.
 # This OSV job is report-only (`continue-on-error: true`, and deliberately NOT
-# in the CI Gate `needs` list), so it surfaces medium/low findings without
+# in the CI Success `needs` list), so it surfaces medium/low findings without
 # breaking the build. The two gates are therefore NOT redundant, and a green
 # `audit` is a strictly weaker statement than a green `sca`: @astrojs/netlify
 # (Low), @hono/node-server (Medium) and astro (Medium) all sailed past

--- a/scripts/check-ci-aggregator.ts
+++ b/scripts/check-ci-aggregator.ts
@@ -9,7 +9,7 @@
  *
  * WHY THIS EXISTS
  * ---------------
- * Branch protection on `main` requires exactly one context: "CI Gate". That job
+ * Branch protection on `main` requires exactly one context: "CI Success". That job
  * (`ci-gate` in .github/workflows/ci.yml) is `if: always()` and decides pass/fail
  * by reading `join(needs.*.result)` — so its verdict covers precisely the jobs in
  * its hand-maintained `needs:` array, and NOTHING else. A job missing from that
@@ -64,7 +64,7 @@ const WORKFLOW = `${WORKFLOW_DIR}/ci.yml`
 
 /**
  * The aggregate job's key. This is the identity of the required status check
- * ("CI Gate" is its `name:`), not an assumption about the job graph — every other
+ * ("CI Success" is its `name:`), not an assumption about the job graph — every other
  * job name in this file is derived at runtime. It lives here as a single named
  * constant precisely so a rename is a one-line change: if the gate is renamed,
  * branch protection has to be updated in the same breath, and this check failing
@@ -223,7 +223,7 @@ if (jobs.length === 0) {
 if (!jobs.includes(AGGREGATOR)) {
   fail(
     `No \`${AGGREGATOR}\` job in ${WORKFLOW}.\n\n` +
-      '"CI Gate" is the only required status check on main. If the aggregate job was\n' +
+      '"CI Success" is the only required status check on main. If the aggregate job was\n' +
       'renamed, update AGGREGATOR in scripts/check-ci-aggregator.ts AND the\n' +
       'branch-protection ruleset.'
   )
@@ -265,7 +265,7 @@ const problems = [
 if (problems.length > 0) {
   fail(
     `${WORKFLOW}\n\n${problems.join('\n')}\n\n` +
-      '"CI Gate" is the ONLY required status check on main, and it can only fail on a\n' +
+      '"CI Success" is the ONLY required status check on main, and it can only fail on a\n' +
       `job it \`needs:\`. Fix the list at ${WORKFLOW} → ${AGGREGATOR}: → needs:, or — for\n` +
       'a deliberate opt-out — add the job to EXCLUDED in scripts/check-ci-aggregator.ts\n' +
       'with a one-line reason.'
@@ -278,7 +278,7 @@ const exemptions =
     : `\nExempt by allowlist: ${[...EXCLUDED].map(([job, why]) => `${job} (${why})`).join('; ')}.`
 
 console.log(
-  `CI aggregator guard passed: "CI Gate" (${AGGREGATOR}) gates all ${gated.length} jobs in ` +
+  `CI aggregator guard passed: "CI Success" (${AGGREGATOR}) gates all ${gated.length} jobs in ` +
     `${WORKFLOW}.${exemptions}\n` +
     `Scope: \`needs:\` reaches only inside one workflow file, so this says nothing about ` +
     `${otherWorkflows().join(', ')}. If any job in those ever becomes a required status ` +

--- a/scripts/check-workspace-scripts.ts
+++ b/scripts/check-workspace-scripts.ts
@@ -13,8 +13,8 @@
  * omits `lint`/`test`/`typecheck` would drop out of every gate unnoticed.
  *
  * Wiring: this guard runs at the head of the root `check` chain and as its own
- * CI job feeding the CI Gate, so a newly-added package that forgets a standard
- * script fails the build instead of quietly opting out.
+ * CI job feeding the CI Success gate, so a newly-added package that forgets a
+ * standard script fails the build instead of quietly opting out.
  */
 
 import { readFileSync, readdirSync, statSync } from 'node:fs'


### PR DESCRIPTION
Closes #1205

Renames this repo's aggregate CI gate job so its **display name is `CI Success`**, matching `binfinite-app`. Cross-repo standardization across the four monorepos that share this CI topology (`randsum`, `binfinite-app`, `SU-SRD`, `optfall`), so `agent-friendly-repo` can apply one ruleset checklist instead of a bespoke one per repo.

## MERGE WARNING — the required status check must be updated by hand, in this order

The required-check name is what branch protection matches on. **This PR deliberately does not touch the ruleset**, so merging it renames the check that CI produces while the ruleset still requires the old name. Every PR then blocks forever waiting for a check that can no longer arrive.

Do this, in order:

1. **Merge this PR** so a run producing `CI Success` exists on `main`.
2. **Update the `main` ruleset's required status check to `CI Success`.**
3. **Remove `CI Gate` from the ruleset.**

Steps 2 and 3 are manual, human-only actions. Nothing in this PR performs them.

### Repo-specific hazard: Dependabot auto-merge will stall in the window

This repo has a Dependabot auto-merge workflow (`.github/workflows/auto-merge.yml`) that calls `gh pr merge --auto`. **Auto-merge waits on the required check.** Any Dependabot PR opened between steps 1 and 2 will sit with auto-merge armed against a check name that no longer arrives, and will silently never land.

Mitigation — pick one:

- **Keep the window short.** Do step 2 immediately after this merges, not "later today."
- **Or pause the workflow while the window is open** (`gh workflow disable auto-merge.yml -R RANDSUM/randsum`, re-enable after step 3). Safer if there is any gap between the merge and the ruleset edit.

Any PR already stalled when step 2 completes needs a nudge to re-evaluate — re-run it or push an empty commit.

## What changed

Purely a rename. **Nothing about what CI checks changes:** the job key stays `ci-gate`, the `needs:` list is untouched, and no job was added, removed, or reordered.

| File | Change |
|---|---|
| `.github/workflows/ci.yml` | `ci-gate` job's `name:` → `CI Success` (the only functional change); 3 prose references |
| `.github/workflows/workflow-lint.yml` | prose reference |
| `lefthook.yml` | prose reference |
| `osv-scanner.toml` | prose reference in the two-gates note |
| `.dependency-cruiser.cjs` | prose reference |
| `scripts/check-workspace-scripts.ts` | prose reference in the wiring docblock |

The prose references were updated so a grep for the gate still finds every place that describes it — a stale "CI Gate" in a comment is exactly the kind of thing that makes the next person doubt which name the ruleset wants. They read "the CI Success gate" because "the CI Success" alone is not a noun phrase; the word "gate" stays accurate since the job key is still `ci-gate`. A lowercase generic "the CI gate" in `scripts/sca-scan.sh` was left alone — it describes the concept, not the job's display name.

`actionlint` passes on both touched workflows.

## Note on CI: the `audit` job is red for an unrelated, pre-existing reason

Two **new** high advisories landed upstream since `main` last ran green (2026-08-11) and are not in the `--ignore` list: `nanoid` (GHSA-2v37-7h3g-55p8) and `extract-zip` (GHSA-jmr9-qjv8-65gv). `bun audit --audit-level=high` fails on `main` itself right now, so it fails here too and takes `CI Success` red with it.

**This is not caused by this PR** — the diff touches no dependency files (no `bun.lock`, no `package.json`). It needs its own fix, in the shape of #1197, and it blocks step 1 above: this PR cannot merge until the audit gate is green again.
