### PR TITLE
fix(security): clear both advisory gates — nanoid floor, the unfixable extract-zip advisory, and the three fixable sca findings

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -331,12 +331,14 @@ jobs:
   sca:
     # SCA + license surfacing (audit X8a / security R2, F1, F2). Suppresses the
     # known dev/build-time advisories via osv-scanner.toml and surfaces LGPL/MPL
-    # transitives. Report-only, and NOT expected to be green: `bun audit` above
-    # is the blocking advisory gate, while this job deliberately reports what
-    # that gate does not cover — anything below `high`, currently
-    # @hono/node-server. `continue-on-error: true` plus its absence from the
+    # transitives. Report-only: `bun audit` above is the blocking advisory gate,
+    # while this job deliberately reports what that gate does not cover —
+    # anything below `high`. `continue-on-error: true` plus its absence from the
     # `CI Gate` needs list is what keeps those findings informative rather than
-    # blocking. See osv-scanner.toml for the per-advisory reasoning.
+    # blocking. It is currently green (the two Medium and one Low it used to
+    # report — @astrojs/netlify, @hono/node-server, astro — all had published
+    # fixes and were bumped), so a new finding here is genuinely new. See
+    # osv-scanner.toml for the per-advisory reasoning.
     name: sca
     runs-on: ubuntu-latest
     continue-on-error: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -301,7 +301,7 @@ jobs:
     # wherever a patched release is usable, so --ignore is reserved for the ones
     # where it is not.
     #
-    # Three suppressions, all dev/build-time only and none in a published
+    # Four suppressions, all dev/build-time only and none in a published
     # package. Full justification and re-evaluation criteria live in
     # osv-scanner.toml — keep the two lists in sync.
     #
@@ -312,12 +312,21 @@ jobs:
     #                        read-yaml-file@1 still needs the removed safeLoad.
     #   GHSA-5p2g-fcmc-qvqq  image-size. No fixed version published.
     #   GHSA-w3rx-r6r6-pgpr  image-size. No fixed version published.
+    #   GHSA-jmr9-qjv8-65gv  extract-zip. No fixed version published at ANY
+    #                        version — latest IS 2.0.1 and the advisory covers
+    #                        <=2.0.1, so no override can resolve it, and the
+    #                        latest @netlify/functions-dev (1.3.5) still
+    #                        requires extract-zip ^2.0.1. Build/dev-time only,
+    #                        reached via apps/site -> @astrojs/netlify ->
+    #                        @netlify/vite-plugin -> @netlify/dev ->
+    #                        @netlify/functions-dev, under the PRIVATE apps/site
+    #                        workspace. An accepted exposure, not a fix.
     name: audit
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - uses: ./.github/actions/bun-setup
-      - run: bun audit --audit-level=high --ignore=GHSA-5p4m-2wfm-xmqj --ignore=GHSA-5p2g-fcmc-qvqq --ignore=GHSA-w3rx-r6r6-pgpr
+      - run: bun audit --audit-level=high --ignore=GHSA-5p4m-2wfm-xmqj --ignore=GHSA-5p2g-fcmc-qvqq --ignore=GHSA-w3rx-r6r6-pgpr --ignore=GHSA-jmr9-qjv8-65gv
 
   sca:
     # SCA + license surfacing (audit X8a / security R2, F1, F2). Suppresses the

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -21,6 +21,25 @@ jobs:
       # here: this job exists to catch NEWLY-published advisories against
       # unchanged code, so carrying the known-baseline suppressions is what
       # keeps a red run meaningful. Without them it fails every Monday on the
-      # same three findings and stops distinguishing new from known.
+      # same four findings and stops distinguishing new from known.
+      #
+      #   GHSA-5p4m-2wfm-xmqj  js-yaml. Patched 3.15.1/4.3.1 unusable (4.3.1's
+      #                        ESM exports map breaks `astro build`; Bun cannot
+      #                        split the two majors). Build/release tooling only.
+      #   GHSA-5p2g-fcmc-qvqq  image-size. No fixed version published.
+      #   GHSA-w3rx-r6r6-pgpr  image-size. No fixed version published.
+      #   GHSA-jmr9-qjv8-65gv  extract-zip. No fixed version published at ANY
+      #                        version — latest IS 2.0.1 and the advisory covers
+      #                        <=2.0.1, and the latest @netlify/functions-dev
+      #                        (1.3.5) still requires extract-zip ^2.0.1.
+      #                        Build/dev-time only, via apps/site ->
+      #                        @astrojs/netlify -> @netlify/vite-plugin ->
+      #                        @netlify/dev -> @netlify/functions-dev, under the
+      #                        PRIVATE apps/site workspace. Accepted, not fixed.
+      #                        THIS ONE IS THE MOST LIKELY TO BECOME STALE — it
+      #                        is suppressed only because upstream offers no
+      #                        patched release, so this weekly run is the place
+      #                        the re-evaluation condition in osv-scanner.toml
+      #                        should actually get noticed.
       - name: Security audit
-        run: bun audit --audit-level=high --ignore=GHSA-5p4m-2wfm-xmqj --ignore=GHSA-5p2g-fcmc-qvqq --ignore=GHSA-w3rx-r6r6-pgpr
+        run: bun audit --audit-level=high --ignore=GHSA-5p4m-2wfm-xmqj --ignore=GHSA-5p2g-fcmc-qvqq --ignore=GHSA-w3rx-r6r6-pgpr --ignore=GHSA-jmr9-qjv8-65gv

--- a/apps/rdn/package.json
+++ b/apps/rdn/package.json
@@ -17,7 +17,7 @@
   },
   "type": "module",
   "dependencies": {
-    "astro": "7.0.6"
+    "astro": "7.1.0"
   },
   "engines": {
     "node": ">=22.12.0",

--- a/apps/site/package.json
+++ b/apps/site/package.json
@@ -17,13 +17,13 @@
   },
   "type": "module",
   "dependencies": {
-    "@astrojs/netlify": "8.1.1",
+    "@astrojs/netlify": "8.1.2",
     "@astrojs/react": "6.0.1",
     "@astrojs/starlight": "0.41.3",
     "@randsum/dice-ui": "workspace:~",
     "@randsum/roller": "workspace:~",
     "@stackblitz/sdk": "~1.11.0",
-    "astro": "7.0.6",
+    "astro": "7.1.0",
     "astro-expressive-code": "0.44.0",
     "react": "catalog:",
     "react-dom": "catalog:"

--- a/bun.lock
+++ b/bun.lock
@@ -143,6 +143,7 @@
     "fast-uri": ">=3.1.5 <4",
     "hono": ">=4.12.34 <5",
     "ip-address": ">=10.3.1 <11",
+    "nanoid": ">=3.3.18 <4",
     "postcss": ">=8.5.23 <9",
     "sharp": ">=0.35.0 <1",
     "svgo": ">=4.0.2 <5",
@@ -2121,7 +2122,7 @@
 
     "muggle-string": ["muggle-string@0.4.1", "", {}, "sha512-VNTrAak/KhO2i8dqqnqnAHOa3cYBwXEZe9h+D5h/1ZqFSTEFHdM65lR7RoIqq3tBBYavsOXV84NoHXZ0AkPyqQ=="],
 
-    "nanoid": ["nanoid@5.1.16", "", { "bin": { "nanoid": "bin/nanoid.js" } }, "sha512-kVrnsrJqMR8+oLJnGEmSWw9BivK5mt7H3FZatVRjrc5wGqFYuBxX1yG7+A7Gi5AefkX6t/oCkizcQgpu0cY1dQ=="],
+    "nanoid": ["nanoid@3.3.18", "", { "bin": { "nanoid": "bin/nanoid.cjs" } }, "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w=="],
 
     "nanospinner": ["nanospinner@1.2.2", "", { "dependencies": { "picocolors": "^1.1.1" } }, "sha512-Zt/AmG6qRU3e+WnzGGLuMCEAO/dAu45stNbHY223tUxldaDAeE+FxSPsd9Q+j+paejmm0ZbrNVs5Sraqy3dRxA=="],
 
@@ -2996,8 +2997,6 @@
     "parse-imports/es-module-lexer": ["es-module-lexer@1.7.0", "", {}, "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA=="],
 
     "parse5/entities": ["entities@6.0.1", "", {}, "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g=="],
-
-    "postcss/nanoid": ["nanoid@3.3.17", "", { "bin": { "nanoid": "bin/nanoid.cjs" } }, "sha512-xQLf0A3HOMlgHq0n247/LRuAOYmB7dXJ/DvAxGvsSBij45XtBSmQycu+F8ODbHwns/XyFZagyL1+J0Offw1E0g=="],
 
     "precinct/commander": ["commander@12.1.0", "", {}, "sha512-Vw8qHK3bZM9y/P10u3Vib8o/DdkvA2OtPtZvD871QKjy74Wj1WSKFILMPRPSdUSx5RFK1arlJzEtA4PkFgnbuA=="],
 

--- a/bun.lock
+++ b/bun.lock
@@ -42,7 +42,7 @@
       "name": "@randsum/rdn",
       "version": "1.0.0",
       "dependencies": {
-        "astro": "7.0.6",
+        "astro": "7.1.0",
       },
       "devDependencies": {
         "@astrojs/check": "0.9.9",
@@ -55,13 +55,13 @@
       "name": "@randsum/site",
       "version": "1.1.2",
       "dependencies": {
-        "@astrojs/netlify": "8.1.1",
+        "@astrojs/netlify": "8.1.2",
         "@astrojs/react": "6.0.1",
         "@astrojs/starlight": "0.41.3",
         "@randsum/dice-ui": "workspace:~",
         "@randsum/roller": "workspace:~",
         "@stackblitz/sdk": "~1.11.0",
-        "astro": "7.0.6",
+        "astro": "7.1.0",
         "astro-expressive-code": "0.44.0",
         "react": "catalog:",
         "react-dom": "catalog:",
@@ -133,6 +133,7 @@
     },
   },
   "overrides": {
+    "@hono/node-server": ">=1.19.15 <2",
     "@opentelemetry/context-async-hooks": ">=2.8.0",
     "@opentelemetry/core": ">=2.8.0",
     "@opentelemetry/resources": ">=2.8.0",
@@ -166,27 +167,27 @@
 
     "@astrojs/compiler": ["@astrojs/compiler@2.13.1", "", {}, "sha512-f3FN83d2G/v32ipNClRKgYv30onQlMZX1vCeZMjPsMMPl1mDpmbl0+N5BYo4S/ofzqJyS5hvwacEo0CCVDn/Qg=="],
 
-    "@astrojs/compiler-binding": ["@astrojs/compiler-binding@0.3.0", "", { "optionalDependencies": { "@astrojs/compiler-binding-darwin-arm64": "0.3.0", "@astrojs/compiler-binding-darwin-x64": "0.3.0", "@astrojs/compiler-binding-linux-arm64-gnu": "0.3.0", "@astrojs/compiler-binding-linux-arm64-musl": "0.3.0", "@astrojs/compiler-binding-linux-x64-gnu": "0.3.0", "@astrojs/compiler-binding-linux-x64-musl": "0.3.0", "@astrojs/compiler-binding-wasm32-wasi": "0.3.0", "@astrojs/compiler-binding-win32-arm64-msvc": "0.3.0", "@astrojs/compiler-binding-win32-x64-msvc": "0.3.0" } }, "sha512-zlsOT5COD9hRwplJCgQhS21unxON5AKirf0vgt1ijXwuseYIaZdm2ZOpF8fsz+DY9EyXx+I/ukxtg7uoBep68A=="],
+    "@astrojs/compiler-binding": ["@astrojs/compiler-binding@0.3.2", "", { "optionalDependencies": { "@astrojs/compiler-binding-darwin-arm64": "0.3.2", "@astrojs/compiler-binding-darwin-x64": "0.3.2", "@astrojs/compiler-binding-linux-arm64-gnu": "0.3.2", "@astrojs/compiler-binding-linux-arm64-musl": "0.3.2", "@astrojs/compiler-binding-linux-x64-gnu": "0.3.2", "@astrojs/compiler-binding-linux-x64-musl": "0.3.2", "@astrojs/compiler-binding-wasm32-wasi": "0.3.2", "@astrojs/compiler-binding-win32-arm64-msvc": "0.3.2", "@astrojs/compiler-binding-win32-x64-msvc": "0.3.2" } }, "sha512-8w/9CWmYrAJJ8N0SY3O43ws2BgxoW6u3QsD8u2mE140lMYAlwh+tlNoUeSBq22wVheFuiBbR212l6ixZ2IIgCQ=="],
 
-    "@astrojs/compiler-binding-darwin-arm64": ["@astrojs/compiler-binding-darwin-arm64@0.3.0", "", { "os": "darwin", "cpu": "arm64" }, "sha512-3n0uu+uJpnCq8b4JFi3uGDsIisAvHctxSmH+cIO9Gbei1H1Y1QXaYboXyiWJugUmprr3OEYP7+LdodzpVFzLMQ=="],
+    "@astrojs/compiler-binding-darwin-arm64": ["@astrojs/compiler-binding-darwin-arm64@0.3.2", "", { "os": "darwin", "cpu": "arm64" }, "sha512-MM8tn8CSimcfytaOla4b6acN8mKWiL/rlAA1fpT3/Wl7dNGSE4y8FjTN/zJVNnb63CsLWG5zZwCt01TXtDKh9g=="],
 
-    "@astrojs/compiler-binding-darwin-x64": ["@astrojs/compiler-binding-darwin-x64@0.3.0", "", { "os": "darwin", "cpu": "x64" }, "sha512-scxNGKjOBydMo1QR4LtK0FMgh7ubQomJDv953nz2msQFkPKke/0FpPv/cQM0T/kuZdReZQFU8Oz3iOrP/6WHEg=="],
+    "@astrojs/compiler-binding-darwin-x64": ["@astrojs/compiler-binding-darwin-x64@0.3.2", "", { "os": "darwin", "cpu": "x64" }, "sha512-2lXOlzf8xb7jLomRsf/aswh61/NnGusynB2OwFkK6k4pmOtpfXMYnG0PLfXrEvxXYj69NdCnmUYXtHDd+JOOag=="],
 
-    "@astrojs/compiler-binding-linux-arm64-gnu": ["@astrojs/compiler-binding-linux-arm64-gnu@0.3.0", "", { "os": "linux", "cpu": "arm64" }, "sha512-NZrWLolVUANmrnl0zrFK/Sx5Sock1gEUT49ALfMTTCA5Ya2ec/BoJXMIg4KgE+wZcrdXJ8e+WyEhM7YLk/FJkA=="],
+    "@astrojs/compiler-binding-linux-arm64-gnu": ["@astrojs/compiler-binding-linux-arm64-gnu@0.3.2", "", { "os": "linux", "cpu": "arm64" }, "sha512-BmU3kWj7qnLrd4vzm49zFEPJ5oFnn1tCT4Vt9hZbqdU5Cmb8GZl7fn6VFsnNfe7B18a2gIFtVzbLINtYl5kBjQ=="],
 
-    "@astrojs/compiler-binding-linux-arm64-musl": ["@astrojs/compiler-binding-linux-arm64-musl@0.3.0", "", { "os": "linux", "cpu": "arm64" }, "sha512-PjwRmKgMFDsFhg82g0poXlIY8Qn3fMA3hXjaR0coJWJzTJsRH9ATU0j2ocigjtU1h3vL/yR7yLUxGj/lTCq73g=="],
+    "@astrojs/compiler-binding-linux-arm64-musl": ["@astrojs/compiler-binding-linux-arm64-musl@0.3.2", "", { "os": "linux", "cpu": "arm64" }, "sha512-f0heT9ZZEseSu5bHCeb80eL2DH07ArE6U9xi1WT/PEusNjzPmEr3GJsjG1tRLo5VYUUYX7h3ScaqGmGrMOVGmw=="],
 
-    "@astrojs/compiler-binding-linux-x64-gnu": ["@astrojs/compiler-binding-linux-x64-gnu@0.3.0", "", { "os": "linux", "cpu": "x64" }, "sha512-Dr69VJYlnSfyL8gzELW6S4mE41P7TDPn1IKjwMnjdZ7+dxgJI50oMLFSk1LVe26bHmWB3ktuh8fDVK1THI9e9A=="],
+    "@astrojs/compiler-binding-linux-x64-gnu": ["@astrojs/compiler-binding-linux-x64-gnu@0.3.2", "", { "os": "linux", "cpu": "x64" }, "sha512-M8fOUt0itRpqiGyoEA/ij184s8O+hqbCz3+YozRusOOM3osgGljpDThhbKAJjqh82wOo6FioQ4w8PBvU1XMD5Q=="],
 
-    "@astrojs/compiler-binding-linux-x64-musl": ["@astrojs/compiler-binding-linux-x64-musl@0.3.0", "", { "os": "linux", "cpu": "x64" }, "sha512-AEt+bRw8PfImCcyRH1lpXVB8CdmQ1K/wPo5u99iec4/U/XdNvQZ715YVuNzIJpbJXelgQeZ5H2+Ea7XwRyWY5g=="],
+    "@astrojs/compiler-binding-linux-x64-musl": ["@astrojs/compiler-binding-linux-x64-musl@0.3.2", "", { "os": "linux", "cpu": "x64" }, "sha512-/Kebk8sO6HnLeSd691JkaAPfN7CqR9/KEXmWvyNPkaKNGmj8rTZ/lf2uXtnPu92Lan84UrKdIKVPy1fSo2encQ=="],
 
-    "@astrojs/compiler-binding-wasm32-wasi": ["@astrojs/compiler-binding-wasm32-wasi@0.3.0", "", { "dependencies": { "@napi-rs/wasm-runtime": "^1.1.6" }, "cpu": "none" }, "sha512-U80tA1j8V6LjhiTZzVCtG4E8hrNVVNXDGV5fCgJ94q8FU9CPH+XwdDDhLzBybfWhKfyItXmQiZNRPTiPCYTpVg=="],
+    "@astrojs/compiler-binding-wasm32-wasi": ["@astrojs/compiler-binding-wasm32-wasi@0.3.2", "", { "dependencies": { "@napi-rs/wasm-runtime": "^1.2.0" }, "cpu": "none" }, "sha512-pUA6xbcOSB7DhfzIArB8BCAkFfAIqriiR7zl5zOStd6oU2G0kIKj+GUdGnyXyhfiv881Hffyk5tC0mR18sDjDw=="],
 
-    "@astrojs/compiler-binding-win32-arm64-msvc": ["@astrojs/compiler-binding-win32-arm64-msvc@0.3.0", "", { "os": "win32", "cpu": "arm64" }, "sha512-CpY1RII2r1XMpOUVD1VR/F2wtuRsiOCkFULS10Khyj8/DFZMtxVuUCAWGw+CW2Ka0h6eP3Xc1CA+glFlvXMPxA=="],
+    "@astrojs/compiler-binding-win32-arm64-msvc": ["@astrojs/compiler-binding-win32-arm64-msvc@0.3.2", "", { "os": "win32", "cpu": "arm64" }, "sha512-ESruf+6Qkl1trHUFxI6GSf6t52j8yN2kCNSzMWdzt7V/T09tFHrYzrVaJQohb2C9bJUH76pNvX6Zb51+xCQc9Q=="],
 
-    "@astrojs/compiler-binding-win32-x64-msvc": ["@astrojs/compiler-binding-win32-x64-msvc@0.3.0", "", { "os": "win32", "cpu": "x64" }, "sha512-qmFbs769oeeGrRebAnCW7aBk8m71vf85W/dX/jddfx5Z06/w0wf7TZCfJPOX1Fld2t+4N+iXzfGEJG+zJQ+bzg=="],
+    "@astrojs/compiler-binding-win32-x64-msvc": ["@astrojs/compiler-binding-win32-x64-msvc@0.3.2", "", { "os": "win32", "cpu": "x64" }, "sha512-wzzVrEbOwbsLWOdEbocskjMRx2aZPxJ7ZbmL+jnpBamFwmigm+2M/wzuM6JWncocgYwLic1csSpalBh96kQKXA=="],
 
-    "@astrojs/compiler-rs": ["@astrojs/compiler-rs@0.3.0", "", { "dependencies": { "@astrojs/compiler-binding": "0.3.0" } }, "sha512-J2qEVHtIDjEM9TxwmwuebOGmZNwhKu/dR7P7qBpnJKGmBBX0vdweQ/4cEXhj8fBbWVUB5V12xWChri3CgKNULQ=="],
+    "@astrojs/compiler-rs": ["@astrojs/compiler-rs@0.3.2", "", { "dependencies": { "@astrojs/compiler-binding": "0.3.2" } }, "sha512-xlx/T7JovIKduu4ucbTQUxQ5+Q8wxkHxhLjnZk3VlJbhbQ9RLvvuDk1p2YYFYFQ5y14dVm3FGGO4isQXa4F+Tg=="],
 
     "@astrojs/internal-helpers": ["@astrojs/internal-helpers@0.10.1", "", { "dependencies": { "@types/hast": "^3.0.4", "@types/mdast": "^4.0.4", "js-yaml": "^4.1.1", "picomatch": "^4.0.4", "retext-smartypants": "^6.2.0", "shiki": "^4.0.2", "smol-toml": "^1.6.0", "unified": "^11.0.5" } }, "sha512-5phcroT/vmOOrYuuAxtkbPixy5hePtlz9i8K4OeDv3dNK6/UQRuXPOSRTxIOBbUY5Sonw2UaxjbuVc43Mcir6Q=="],
 
@@ -194,11 +195,11 @@
 
     "@astrojs/markdown-remark": ["@astrojs/markdown-remark@7.2.1", "", { "dependencies": { "@astrojs/internal-helpers": "0.10.1", "@astrojs/prism": "4.0.2", "github-slugger": "^2.0.0", "hast-util-from-html": "^2.0.3", "hast-util-to-text": "^4.0.2", "mdast-util-definitions": "^6.0.0", "rehype-raw": "^7.0.0", "rehype-stringify": "^10.0.1", "remark-gfm": "^4.0.1", "remark-parse": "^11.0.0", "remark-rehype": "^11.1.2", "remark-smartypants": "^3.0.2", "unified": "^11.0.5", "unist-util-remove-position": "^5.0.0", "unist-util-visit": "^5.1.0", "unist-util-visit-parents": "^6.0.2", "vfile": "^6.0.3" } }, "sha512-jPVNIqTvk+yKviikszv/Y1U4jGUSKpp/Nw48QZV4qjWgp70j4Lkq3lhSDRbWwCfgKvEyO9GHuVbV1dM2WYXy1w=="],
 
-    "@astrojs/markdown-satteri": ["@astrojs/markdown-satteri@0.3.3", "", { "dependencies": { "@astrojs/internal-helpers": "0.10.1", "@astrojs/prism": "4.0.2", "github-slugger": "^2.0.0", "satteri": "^0.9.1" } }, "sha512-Lje33Ittd8UQGgbIIWQvhPkj5X5c4b1sZnZWX3JQV/AWpfbuQGxVi2ONt6+ScydcwfR4egilslEWyczMclrJ1g=="],
+    "@astrojs/markdown-satteri": ["@astrojs/markdown-satteri@0.3.4", "", { "dependencies": { "@astrojs/internal-helpers": "0.10.1", "@astrojs/prism": "4.0.2", "github-slugger": "^2.0.0", "hast-util-from-html": "^2.0.3", "satteri": "^0.9.1" } }, "sha512-6Lvt/bQZEBW+zzdhPblvfZEy5PGEYJaUsUqaCgwHeRPxZJL1gc9I+DRLKWJjjYTWDzVUTzXlMq4WwSK+X34CVw=="],
 
     "@astrojs/mdx": ["@astrojs/mdx@7.0.2", "", { "dependencies": { "@astrojs/internal-helpers": "0.10.1", "@astrojs/markdown-remark": "7.2.1", "@mdx-js/mdx": "^3.1.1", "acorn": "^8.16.0", "es-module-lexer": "^2.0.0", "estree-util-visit": "^2.0.0", "hast-util-to-html": "^9.0.5", "piccolore": "^0.1.3", "rehype-raw": "^7.0.0", "remark-gfm": "^4.0.1", "remark-smartypants": "^3.0.2", "source-map": "^0.7.6", "unist-util-visit": "^5.1.0", "vfile": "^6.0.3" }, "peerDependencies": { "@astrojs/markdown-satteri": "^0.3.1", "astro": "^7.0.0" }, "optionalPeers": ["@astrojs/markdown-satteri"] }, "sha512-l+sJY5U1KkGZUdr+bIL4Y6BefeS549qoSHVSkUSs6A9INwdCND+/0+vN0NroPBXwl5Vcg5u78t7VQRsJjePxbw=="],
 
-    "@astrojs/netlify": ["@astrojs/netlify@8.1.1", "", { "dependencies": { "@astrojs/internal-helpers": "0.10.1", "@astrojs/underscore-redirects": "1.0.3", "@netlify/blobs": "^10.7.4", "@netlify/functions": "^5.2.0", "@netlify/vite-plugin": "^2.12.3", "@vercel/nft": "^1.3.2", "esbuild": "^0.28.0", "tinyglobby": "^0.2.15", "vite": "^8.0.13" }, "peerDependencies": { "astro": "^7.0.0" } }, "sha512-BxSZxyadqpEYEFXndflQoUbpVfwmDSXZMo8i3tjYgMjuHqN0cV3EpKC9ZYV9OMZDWNZjIKPbTn3KxuKlhAWKUA=="],
+    "@astrojs/netlify": ["@astrojs/netlify@8.1.2", "", { "dependencies": { "@astrojs/internal-helpers": "0.10.1", "@astrojs/underscore-redirects": "1.0.3", "@netlify/blobs": "^10.7.4", "@netlify/functions": "^5.2.0", "@netlify/vite-plugin": "^2.12.3", "@vercel/nft": "^1.3.2", "esbuild": "^0.28.0", "tinyglobby": "^0.2.15", "vite": "^8.0.13" }, "peerDependencies": { "astro": "^7.0.0" } }, "sha512-Eiff9qt3bzxqPsRlFIRYb7dCkPFNZneFOA9civif90rx2PO2Nvao9gQiBvHBcA7+awlUeiAXTfV1aJhlQ5lw5w=="],
 
     "@astrojs/prism": ["@astrojs/prism@4.0.2", "", { "dependencies": { "prismjs": "^1.30.0" } }, "sha512-KTivpmnz6lDsC6o9H4+DNm2SrE/GHzw8cNAvEJwAvUT+eoaEnn/4NtbDNfRRaxaJHdp15gf+tfHAWiXR4wB3BA=="],
 
@@ -208,7 +209,7 @@
 
     "@astrojs/starlight": ["@astrojs/starlight@0.41.3", "", { "dependencies": { "@astrojs/markdown-satteri": "^0.3.2", "@astrojs/mdx": "^7.0.0", "@astrojs/sitemap": "^3.7.2", "@pagefind/default-ui": "^1.3.0", "@types/hast": "^3.0.4", "@types/js-yaml": "^4.0.9", "@types/mdast": "^4.0.4", "astro-expressive-code": "^0.44.0", "bcp-47": "^2.1.0", "hast-util-from-html": "^2.0.3", "hast-util-select": "^6.0.4", "hast-util-to-string": "^3.0.1", "hastscript": "^9.0.1", "i18next": "^26.0.7", "js-yaml": "^4.1.1", "klona": "^2.0.6", "magic-string": "^0.30.21", "mdast-util-directive": "^3.1.0", "mdast-util-to-markdown": "^2.1.2", "mdast-util-to-string": "^4.0.0", "pagefind": "^1.5.2", "rehype": "^13.0.2", "rehype-format": "^5.0.1", "remark-directive": "^4.0.0", "satteri": "^0.9.1", "ultrahtml": "^1.6.0", "unified": "^11.0.5", "unist-util-visit": "^5.1.0", "vfile": "^6.0.3" }, "peerDependencies": { "@astrojs/markdown-remark": "^7.2.0", "astro": "^7.0.2" }, "optionalPeers": ["@astrojs/markdown-remark"] }, "sha512-8xsG6UpK581TJmtOc7/pnxHKEbP16rV06VLWaVa7FOyE/VEwnaHOsLtL+miifCEfuiuv0Wn+j8u3JSluRQesMQ=="],
 
-    "@astrojs/telemetry": ["@astrojs/telemetry@3.3.2", "", { "dependencies": { "ci-info": "^4.4.0", "dset": "^3.1.4", "is-docker": "^4.0.0", "is-wsl": "^3.1.1", "which-pm-runs": "^1.1.0" } }, "sha512-j8DNruA8ors99Al39RYZPJK4DC1bKkoNm93mAMuBhY9TCNC4R8n1q7ovFnJ5qhGh5Lsh7pa1gpQVpYpsJPeTHQ=="],
+    "@astrojs/telemetry": ["@astrojs/telemetry@3.3.3", "", { "dependencies": { "ci-info": "^4.4.0", "dset": "^3.1.4", "is-docker": "^4.0.0", "package-manager-detector": "^1.6.0" } }, "sha512-C1TLn5sPJr0x4vk56piHWKbnqlEB8BKyte5Y45V02U+D7BGO5eMqZDH5aPjnkXQWJggvmsTXxH03QMZ9NgWLzQ=="],
 
     "@astrojs/underscore-redirects": ["@astrojs/underscore-redirects@1.0.3", "", {}, "sha512-cxnGSw+sJigBLdX4TMSZKkzV6C3gMLJMucDk2W+n281Xhie68T2/9f1+1NMNDCZsc5i0FED7Qt5I10g2O9wtZg=="],
 
@@ -448,7 +449,7 @@
 
     "@happy-dom/global-registrator": ["@happy-dom/global-registrator@20.10.6", "", { "dependencies": { "@types/node": ">=20.0.0", "happy-dom": "^20.10.6" } }, "sha512-Nu/IjRkkNxmeG2ywWsyJSO4d1BrWTqVzxCPL+gXj0b97klhmjd6wLzt6Bx/laNpkZ3WLW7zNCqmtMIbIlahqug=="],
 
-    "@hono/node-server": ["@hono/node-server@1.19.14", "", { "peerDependencies": { "hono": "^4" } }, "sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw=="],
+    "@hono/node-server": ["@hono/node-server@1.19.17", "", { "peerDependencies": { "hono": "^4" } }, "sha512-dSneS5qhiauZWGDCeK4o695Xd9nUNjviSZCMQrj10eetr8Uln1ucn6bbphOM6UynAMMtNIzZNSpL9vnASJwrPQ=="],
 
     "@humanwhocodes/momoa": ["@humanwhocodes/momoa@2.0.4", "", {}, "sha512-RE815I4arJFtt+FVeU1Tgp9/Xvecacji8w/V6XtXsWWH/wz/eNkNbhb+ny/+PlVZjV0rxQpRSQKNKE3lcktHEA=="],
 
@@ -1114,7 +1115,7 @@
 
     "astring": ["astring@1.9.0", "", { "bin": { "astring": "bin/astring" } }, "sha512-LElXdjswlqjWrPpJFg1Fx4wpkOCxj1TDHlSV4PlaRxHGWko024xICaa97ZkMfs6DRKlCguiAI+rbXv5GWwXIkg=="],
 
-    "astro": ["astro@7.0.6", "", { "dependencies": { "@astrojs/compiler-rs": "^0.3.0", "@astrojs/internal-helpers": "0.10.1", "@astrojs/markdown-satteri": "0.3.3", "@astrojs/telemetry": "3.3.2", "@capsizecss/unpack": "^4.0.0", "@clack/prompts": "^1.1.0", "@oslojs/encoding": "^1.1.0", "@rollup/pluginutils": "^5.3.0", "am-i-vibing": "^0.4.0", "aria-query": "^5.3.2", "axobject-query": "^4.1.0", "ci-info": "^4.4.0", "clsx": "^2.1.1", "common-ancestor-path": "^2.0.0", "cookie": "^1.1.1", "devalue": "^5.8.1", "diff": "^8.0.3", "dset": "^3.1.4", "es-module-lexer": "^2.0.0", "esbuild": "^0.28.0", "flattie": "^1.1.1", "fontace": "~0.4.1", "get-tsconfig": "5.0.0-beta.4", "github-slugger": "^2.0.0", "html-escaper": "3.0.3", "http-cache-semantics": "^4.2.0", "js-yaml": "^4.1.1", "jsonc-parser": "^3.3.1", "magic-string": "^0.30.21", "magicast": "^0.5.2", "mrmime": "^2.0.1", "neotraverse": "^0.6.18", "obug": "^2.1.1", "p-limit": "^7.3.0", "p-queue": "^9.1.0", "package-manager-detector": "^1.6.0", "piccolore": "^0.1.3", "picomatch": "^4.0.4", "semver": "^7.7.4", "shiki": "^4.0.2", "smol-toml": "^1.6.0", "svgo": "^4.0.1", "tinyclip": "^0.1.12", "tinyexec": "^1.0.4", "tinyglobby": "^0.2.15", "ultrahtml": "^1.6.0", "unifont": "~0.7.4", "unstorage": "^1.17.5", "vite": "^8.0.13", "vitefu": "^1.1.2", "xxhash-wasm": "^1.1.0", "yargs-parser": "^22.0.0", "zod": "^4.3.6" }, "optionalDependencies": { "sharp": "^0.34.0 || ^0.35.0" }, "peerDependencies": { "@astrojs/markdown-remark": "7.2.1" }, "optionalPeers": ["@astrojs/markdown-remark"], "bin": { "astro": "./bin/astro.mjs" } }, "sha512-Myw0sFia+zs/Y0yqfZEsUYXfDPh3ELcLf1f0Q/qQzVXBh/af1qO62WNT+P89DCcfGVV51nMoQhEfkBYqJmoUOQ=="],
+    "astro": ["astro@7.1.0", "", { "dependencies": { "@astrojs/compiler-rs": "^0.3.1", "@astrojs/internal-helpers": "0.10.1", "@astrojs/markdown-satteri": "0.3.4", "@astrojs/telemetry": "3.3.3", "@capsizecss/unpack": "^4.0.0", "@clack/prompts": "^1.1.0", "@oslojs/encoding": "^1.1.0", "@rollup/pluginutils": "^5.3.0", "am-i-vibing": "^0.4.0", "aria-query": "^5.3.2", "axobject-query": "^4.1.0", "ci-info": "^4.4.0", "clsx": "^2.1.1", "common-ancestor-path": "^2.0.0", "cookie": "^1.1.1", "devalue": "^5.8.1", "diff": "^8.0.3", "dset": "^3.1.4", "es-module-lexer": "^2.0.0", "esbuild": "^0.28.0", "flattie": "^1.1.1", "fontace": "~0.4.1", "get-tsconfig": "5.0.0-beta.4", "github-slugger": "^2.0.0", "html-escaper": "3.0.3", "http-cache-semantics": "^4.2.0", "js-yaml": "^4.1.1", "jsonc-parser": "^3.3.1", "magic-string": "^0.30.21", "magicast": "^0.5.2", "mrmime": "^2.0.1", "neotraverse": "^0.6.18", "obug": "^2.1.1", "p-limit": "^7.3.0", "p-queue": "^9.1.0", "package-manager-detector": "^1.6.0", "piccolore": "^0.1.3", "picomatch": "^4.0.4", "semver": "^7.7.4", "shiki": "^4.0.2", "smol-toml": "^1.6.0", "svgo": "^4.0.1", "tinyclip": "^0.1.12", "tinyexec": "^1.0.4", "tinyglobby": "^0.2.15", "ultrahtml": "^1.6.0", "unifont": "~0.7.4", "unstorage": "^1.17.5", "vite": "^8.0.13", "vitefu": "^1.1.2", "xxhash-wasm": "^1.1.0", "yargs-parser": "^22.0.0", "zod": "^4.3.6" }, "optionalDependencies": { "sharp": "^0.34.0 || ^0.35.0" }, "peerDependencies": { "@astrojs/markdown-remark": "7.2.1" }, "optionalPeers": ["@astrojs/markdown-remark"], "bin": { "astro": "./bin/astro.mjs" } }, "sha512-jXHNZXpO0HOuANLwv5uLg5WFXFmIMyDTMlokIb8sv10y8QItOFaikwrqvp6+Pe0MSqvp+aO7V1SfVriFcCEKgA=="],
 
     "astro-expressive-code": ["astro-expressive-code@0.44.0", "", { "dependencies": { "rehype-expressive-code": "^0.44.0", "url-extras": "^0.1.0" }, "peerDependencies": { "astro": "^4.0.0-beta || ^5.0.0-beta || ^3.3.0 || ^6.0.0-beta || ^7.0.0" } }, "sha512-b1wN/ZvbJprzxlGKIpIes2kQrCY5KRLwys2tWbZAZyjGZcW5ZtgneZnBwzNRiBna9/48d4mQl19KLjcRuhO1hw=="],
 
@@ -1768,8 +1769,6 @@
 
     "is-hexadecimal": ["is-hexadecimal@2.0.1", "", {}, "sha512-DgZQp241c8oO6cA1SbTEWiXeoxV42vlcJxgH+B3hi1AiqqKruZR3ZGF8In3fj4+/y/7rHvlOZLZtgJ/4ttYGZg=="],
 
-    "is-inside-container": ["is-inside-container@1.0.0", "", { "dependencies": { "is-docker": "^3.0.0" }, "bin": { "is-inside-container": "cli.js" } }, "sha512-KIYLCCJghfHZxqjYBE7rEy0OBuTd5xCHS7tHVgvCLkx7StIoaxwNW3hCALgEUjFfeRk+MG/Qxmp/vtETEF3tRA=="],
-
     "is-installed-globally": ["is-installed-globally@1.0.0", "", { "dependencies": { "global-directory": "^4.0.1", "is-path-inside": "^4.0.0" } }, "sha512-K55T22lfpQ63N4KEN57jZUAaAYqYHEe8veb/TycJRk9DdSCLLcovXz/mL6mOnhQaZsQGwPhuFopdQIlqGSEjiQ=="],
 
     "is-map": ["is-map@2.0.3", "", {}, "sha512-1Qed0/Hr2m+YqxnM09CjA2d/i6YZNfF6R2oRAOj36eUdS6qIV/huPJNSEpKbupewFs+ZsJlxsjjPbc0/afW6Lw=="],
@@ -1815,8 +1814,6 @@
     "is-weakset": ["is-weakset@2.0.4", "", { "dependencies": { "call-bound": "^1.0.3", "get-intrinsic": "^1.2.6" } }, "sha512-mfcwb6IzQyOKTs84CQMrOwW4gQcaTOAWJ0zzJCl2WSPDrWk/OzDaImWFH3djXhb24g4eudZfLRozAvPGw4d9hQ=="],
 
     "is-windows": ["is-windows@1.0.2", "", {}, "sha512-eXK1UInq2bPmjyX6e3VHIzMLobc4J94i4AWn+Hpq3OU5KkrRC96OAcR3PRJ/pGu6m8TRnBHP9dkXQVsT/COVIA=="],
-
-    "is-wsl": ["is-wsl@3.1.1", "", { "dependencies": { "is-inside-container": "^1.0.0" } }, "sha512-e6rvdUCiQCAuumZslxRJWR/Doq4VpPR82kqclvcS0efgt430SlGIk05vdCN58+VrzgtIcfNODjozVielycD4Sw=="],
 
     "isarray": ["isarray@1.0.0", "", {}, "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ=="],
 
@@ -2796,8 +2793,6 @@
 
     "which-collection": ["which-collection@1.0.2", "", { "dependencies": { "is-map": "^2.0.3", "is-set": "^2.0.3", "is-weakmap": "^2.0.2", "is-weakset": "^2.0.3" } }, "sha512-K4jVyjnBdgvc86Y6BkaLZEN933SwYOuBFkdmBu9ZfkcAbdVbpITnDmjvZ/aQjRXQrv5EPkTnD1s39GiiqbngCw=="],
 
-    "which-pm-runs": ["which-pm-runs@1.1.0", "", {}, "sha512-n1brCuqClxfFfq/Rb0ICg9giSZqCS+pLtccdag6C2HyufBrh3fBOiy9nb6ggRMvWOVH5GrdJskj5iGTZNxd7SA=="],
-
     "which-typed-array": ["which-typed-array@1.1.22", "", { "dependencies": { "available-typed-arrays": "^1.0.7", "call-bind": "^1.0.9", "call-bound": "^1.0.4", "for-each": "^0.3.5", "get-proto": "^1.0.1", "gopd": "^1.2.0", "has-tostringtag": "^1.0.2" } }, "sha512-fvO4ExWMFsqyhG3AiPAObMuY1lxaqgYcxbc49CNdWDDECOJNgQyvsOWVwbZc+qf3rzRtxojBK+CMEv0Ld5CYpw=="],
 
     "winston": ["winston@3.19.0", "", { "dependencies": { "@colors/colors": "^1.6.0", "@dabh/diagnostics": "^2.0.8", "async": "^3.2.3", "is-stream": "^2.0.0", "logform": "^2.7.0", "one-time": "^1.0.0", "readable-stream": "^3.4.0", "safe-stable-stringify": "^2.3.1", "stack-trace": "0.0.x", "triple-beam": "^1.3.0", "winston-transport": "^4.9.0" } }, "sha512-LZNJgPzfKR+/J3cHkxcpHKpKKvGfDZVPS4hfJCc4cCG0CgYzvlD6yE/S3CIL/Yt91ak327YCpiF/0MyeZHEHKA=="],
@@ -2844,7 +2839,13 @@
 
     "@astrojs/check/chokidar": ["chokidar@4.0.3", "", { "dependencies": { "readdirp": "^4.0.1" } }, "sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA=="],
 
+    "@astrojs/compiler-binding-wasm32-wasi/@napi-rs/wasm-runtime": ["@napi-rs/wasm-runtime@1.2.3", "", { "dependencies": { "@tybys/wasm-util": "^0.10.3" }, "peerDependencies": { "@emnapi/core": "^1.7.1 || ^2.0.0-alpha.4", "@emnapi/runtime": "^1.7.1 || ^2.0.0-alpha.4" } }, "sha512-UMduMbqO5s5zF2NkNacMT/yK5Y5QiKvWr2+50bzIIxFDwVJ2h49b+oyjaCGPhJxd2/gC2x39EHv/gHVuu36x2Q=="],
+
     "@astrojs/language-server/prettier": ["prettier@3.8.4", "", { "bin": { "prettier": "bin/prettier.cjs" } }, "sha512-N2MylSdi48+5N/6S5j+maeHbUSIzzZ5uOcX5Hm4QpV8Dkb1HFjfAKTKX6yNPJQD9AhcT3ifHNB66tWTTJDi11Q=="],
+
+    "@astrojs/starlight/@astrojs/markdown-satteri": ["@astrojs/markdown-satteri@0.3.3", "", { "dependencies": { "@astrojs/internal-helpers": "0.10.1", "@astrojs/prism": "4.0.2", "github-slugger": "^2.0.0", "satteri": "^0.9.1" } }, "sha512-Lje33Ittd8UQGgbIIWQvhPkj5X5c4b1sZnZWX3JQV/AWpfbuQGxVi2ONt6+ScydcwfR4egilslEWyczMclrJ1g=="],
+
+    "@astrojs/telemetry/package-manager-detector": ["package-manager-detector@1.7.0", "", {}, "sha512-xg1eHpwYL/D/HEdWw2goFZP6vV0FH7W+PZ5rFkGjdIDLtxq7EkzBUeT3m+lndYCt8wKbmofUu1MUdMCXkCk9ZQ=="],
 
     "@babel/core/semver": ["semver@6.3.1", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA=="],
 
@@ -2961,8 +2962,6 @@
     "globby/ignore": ["ignore@5.3.2", "", {}, "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g=="],
 
     "hosted-git-info/lru-cache": ["lru-cache@10.4.3", "", {}, "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ=="],
-
-    "is-inside-container/is-docker": ["is-docker@3.0.0", "", { "bin": { "is-docker": "cli.js" } }, "sha512-eljcgEDlEns/7AXFosB5K/2nCM4P7FQPkGc/DWLy5rmFEWvZayGrik1d9/QIY5nJ4f9YsVvBkA6kJpHn9rISdQ=="],
 
     "lambda-local/commander": ["commander@10.0.1", "", {}, "sha512-y4Mg2tXshplEbSGzx7amzPwKKOCGuoSRP/CjEdwwk0FOGlUbq6lKuoyDZTNZkmxHdJtp54hdfY/JUrdL7Xfdug=="],
 

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -51,9 +51,17 @@ pre-push:
       # Dependency advisory gate. Also runs in CI (ci.yml `audit` job) so it cannot
       # be bypassed with --no-verify. The --ignore list MUST match the CI job and
       # osv-scanner.toml; that file carries the per-advisory justification.
-      # Currently: js-yaml (patched release breaks `astro build`) and image-size
-      # x2 (no fixed version published).
-      run: bun audit --audit-level=high --ignore=GHSA-5p4m-2wfm-xmqj --ignore=GHSA-5p2g-fcmc-qvqq --ignore=GHSA-w3rx-r6r6-pgpr > /dev/null 2>&1
+      # Currently:
+      #   GHSA-5p4m-2wfm-xmqj  js-yaml     — patched release breaks `astro build`
+      #   GHSA-5p2g-fcmc-qvqq  image-size  — no fixed version published
+      #   GHSA-w3rx-r6r6-pgpr  image-size  — no fixed version published
+      #   GHSA-jmr9-qjv8-65gv  extract-zip — no fixed version published at ANY
+      #     version (latest IS 2.0.1, advisory covers <=2.0.1; latest
+      #     @netlify/functions-dev 1.3.5 still requires ^2.0.1). Build/dev-time
+      #     only, via apps/site -> @astrojs/netlify -> @netlify/vite-plugin ->
+      #     @netlify/dev -> @netlify/functions-dev, under the PRIVATE apps/site
+      #     workspace. An accepted exposure, not a fix.
+      run: bun audit --audit-level=high --ignore=GHSA-5p4m-2wfm-xmqj --ignore=GHSA-5p2g-fcmc-qvqq --ignore=GHSA-w3rx-r6r6-pgpr --ignore=GHSA-jmr9-qjv8-65gv > /dev/null 2>&1
       priority: 2
     sca:
       # Local mirror of the CI `sca` job (OSV-Scanner against bun.lock, honouring

--- a/osv-scanner.toml
+++ b/osv-scanner.toml
@@ -2,16 +2,17 @@
 #
 # Most previously-accepted dev/build-time transitive advisories are
 # FORCE-RESOLVED via `overrides` in the root package.json (yaml, esbuild,
-# @opentelemetry/*), so they need no suppression here — the scanner sees the
-# patched versions directly. (The former uuid finding is gone entirely with the
-# expo app removed in #1121.)
+# nanoid, @opentelemetry/*), so they need no suppression here — the scanner sees
+# the patched versions directly. (The former uuid finding is gone entirely with
+# the expo app removed in #1121.)
 #
 # Everything suppressed below is dev/build-time only, and none of it reaches a
 # published package. The four published packages are @randsum/roller (zero
 # deps), @randsum/games (depends only on @randsum/roller), @randsum/cli (zero
 # runtime deps) and @randsum/mcp — the last is the only one with real runtime
 # dependencies (@modelcontextprotocol/sdk, zod), so it is the one worth
-# re-checking: neither js-yaml nor image-size appears beneath it in bun.lock.
+# re-checking: none of js-yaml, image-size or extract-zip appears beneath it in
+# bun.lock.
 #
 # NOTE ON THE TWO GATES. `bun audit --audit-level=high` is the blocking gate.
 # This OSV job is report-only (`continue-on-error: true`, and deliberately NOT
@@ -78,3 +79,47 @@ reason = "image-size: JXL and HEIF parsers allow denial of service through infin
 [[IgnoredVulns]]
 id = "GHSA-w3rx-r6r6-pgpr"
 reason = "image-size: ICNS parser allows denial of service through an infinite loop. Same package, same reachability and reasoning as GHSA-5p2g-fcmc-qvqq. No fixed version published."
+
+# --- extract-zip: no fix exists at any version -------------------------------
+#
+# ACCEPTED EXPOSURE, NOT A RESOLVED ONE. Unlike nanoid — which had a published
+# 3.3.18 and so got an `overrides` floor rather than an entry here — extract-zip
+# has nothing to float to. Its LATEST published version IS 2.0.1 and the
+# advisory covers <=2.0.1, so no override can resolve it. Verified, not assumed.
+#
+# Full path into the tree, all of it build/dev-time:
+#
+#   apps/site (private)
+#     -> @astrojs/netlify
+#       -> @netlify/vite-plugin
+#         -> @netlify/dev
+#           -> @netlify/functions-dev
+#             -> extract-zip ^2.0.1
+#
+# Upstream does not offer a way out today. The locked @netlify/functions-dev is
+# 1.3.0; the latest published is 1.3.5 and it STILL declares `extract-zip
+# ^2.0.1`. Bumping @astrojs/netlify 8.1.1 -> 8.2.1 does not drop the path
+# either. So this is not a stale-lockfile problem that an update would clear.
+#
+# Reachability is bounded: extract-zip is only exercised by the Netlify local
+# dev/functions tooling unpacking archives it fetches itself, under the PRIVATE
+# apps/site workspace. It is not in any published package (see the header note),
+# and it never unpacks user- or contributor-supplied archives in this repo. The
+# advisory is a symlink path traversal during extraction, which needs an
+# attacker-authored zip to matter.
+#
+# RE-EVALUATE WHEN: `@netlify/functions-dev` drops the `extract-zip ^2.0.1`
+# dependency, or extract-zip publishes any version above 2.0.1. Check with
+# `bun pm view @netlify/functions-dev dependencies` and `bun pm view extract-zip
+# version` — both were checked when this entry was added and neither had moved.
+# This is a condition, not a date; nothing expires it automatically.
+#
+# NOT A RANDSUM QUIRK. The same advisory, with the same null patched version, is
+# blocking the audit gate in the Binfinite repo through the same Netlify dev
+# toolchain (alongside two image-size advisories that are likewise unfixable).
+# It is a portfolio-wide upstream problem, so the condition above is worth
+# re-checking for more than this repo.
+
+[[IgnoredVulns]]
+id = "GHSA-jmr9-qjv8-65gv"
+reason = "extract-zip: unvalidated symlink path traversal during extraction. No fixed version published at any version — latest IS 2.0.1 and the advisory covers <=2.0.1, so no override can resolve it; latest @netlify/functions-dev (1.3.5) still requires extract-zip ^2.0.1. Build/dev-time only, via apps/site -> @astrojs/netlify -> @netlify/vite-plugin -> @netlify/dev -> @netlify/functions-dev, under the private apps/site workspace; never in a published package, and never unpacking contributor-supplied archives. Re-evaluate when @netlify/functions-dev drops the dependency or extract-zip publishes above 2.0.1."

--- a/osv-scanner.toml
+++ b/osv-scanner.toml
@@ -16,8 +16,12 @@
 #
 # NOTE ON THE TWO GATES. `bun audit --audit-level=high` is the blocking gate.
 # This OSV job is report-only (`continue-on-error: true`, and deliberately NOT
-# in the CI Gate `needs` list), so it surfaces medium/low findings — currently
-# @hono/node-server — without breaking the build.
+# in the CI Gate `needs` list), so it surfaces medium/low findings without
+# breaking the build. The two gates are therefore NOT redundant, and a green
+# `audit` is a strictly weaker statement than a green `sca`: @astrojs/netlify
+# (Low), @hono/node-server (Medium) and astro (Medium) all sailed past
+# `--audit-level=high` and stopped only here. All three had published fixes and
+# were bumped rather than suppressed, so this scan is currently clean.
 #
 # KEEPING THE LISTS IN SYNC. `bun audit --ignore` flags appear in THREE places:
 #   .github/workflows/ci.yml   (audit job — the blocking gate)

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "ip-address": ">=10.3.1 <11",
     "brace-expansion": ">=2.1.4 <3 || >=5.0.9",
     "hono": ">=4.12.34 <5",
+    "nanoid": ">=3.3.18 <4",
     "tar": ">=7.5.21 <8",
     "@opentelemetry/core": ">=2.8.0",
     "@opentelemetry/resources": ">=2.8.0",

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "ip-address": ">=10.3.1 <11",
     "brace-expansion": ">=2.1.4 <3 || >=5.0.9",
     "hono": ">=4.12.34 <5",
+    "@hono/node-server": ">=1.19.15 <2",
     "nanoid": ">=3.3.18 <4",
     "tar": ">=7.5.21 <8",
     "@opentelemetry/core": ">=2.8.0",

--- a/scripts/sca-scan.sh
+++ b/scripts/sca-scan.sh
@@ -19,7 +19,18 @@
 set -euo pipefail
 
 OSV_IMAGE="ghcr.io/google/osv-scanner-action:v2.3.8"
-ARGS=(--config=osv-scanner.toml --recursive ./)
+
+# `-L bun.lock` rather than CI's `--recursive ./`, and the difference is
+# load-bearing rather than cosmetic. OSV-Scanner's directory walk honours
+# .gitignore, and line 106 of ours ignores `.claude/worktrees/` — which is
+# exactly where agent worktrees live. Run from one, the walk skips the entire
+# tree, prints "No package sources found" and exits 128, so this pre-push step
+# was unpassable from any worktree for a tooling reason that looks nothing like
+# a tooling reason. Scanning the lockfile directly is immune to that, and loses
+# nothing: bun.lock is the only package source in the repo, so it is what the
+# recursive walk resolves to in the checkout anyway. CI keeps `--recursive ./`
+# because it runs on a clean checkout with no worktrees.
+ARGS=(--config=osv-scanner.toml -L bun.lock)
 
 repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 cd "$repo_root"


### PR DESCRIPTION
## Why this exists

The `audit` job — and therefore `sca` and the **CI Gate** — is currently red on **every open PR in this repo, including Dependabot's**. None of those PRs introduced it. Two advisories were published after main's last green `ci.yml` run, so they fail against unchanged code and every branch inherits them.

This PR clears both, and then clears what `sca` was still reporting underneath them. It is deliberately **four commits, different in kind**, and they should be reviewed and reverted separately:

| Commit | Advisory | What it is |
|---|---|---|
| `815ac83c` | `GHSA-2v37-7h3g-55p8` nanoid `<3.3.18` | **A real fix.** Raises a floor to a patched release. |
| `ae268794` | `GHSA-jmr9-qjv8-65gv` extract-zip `<=2.0.1` | **An accepted exposure.** No patched release exists anywhere. |
| `92520e80` | three advisories below `high` (below) | **A real fix at a different severity floor.** All three had published fixes. |
| `ccb32535` | — | **A tooling fix.** The local `sca` mirror could not pass from an agent worktree. |

They cannot be split into separate PRs: the `lefthook.yml` pre-push audit gate blocks the nanoid push until the extract-zip suppression exists, so the two are coupled by the gate itself.

### The two gates are not redundant, and `sca` is the stricter one

Worth stating up front, because the naming suggests the opposite. `audit` runs `bun audit --audit-level=high`; `sca` (OSV-Scanner) has **no severity floor at all**. So a green `audit` is a strictly weaker statement than a green `sca`, and clearing the blocking gate in the first two commits left three findings — two Medium and one Low — sailing straight past it and stopping only at the report-only one. `sca` is `continue-on-error: true` and absent from the CI Gate `needs` list, so those findings never blocked anything; they were simply never green. The third commit clears them.

---

## Commit 1 — nanoid: an actual fix

Adds `"nanoid": ">=3.3.18 <4"` to the root `overrides`, matching the existing security-floor style and [the same floor already carried in `SalvageUnion-io/SU-SRD`](https://github.com/SalvageUnion-io/SU-SRD).

**The upper bound is load-bearing.** SU-SRD uses a bare `^3.3.18`; copying that here would have been wrong. This tree carried **two nanoid majors**:

- `nanoid@3.3.17` nested under `postcss` — the genuinely vulnerable one, and the one every reported path funnels through (`astro` and the `@astrojs/*` adapters reach it via `vite` → `postcss`)
- `nanoid@5.1.16` under `@size-limit/esbuild` — not in the advisory's range at all

Bun collapses `overrides` to a single version tree-wide and does not support nested overrides — the same trap `osv-scanner.toml` already documents for js-yaml. An unbounded `>=3.3.18` would therefore have dragged the whole tree to 6.x. `>=3.3.18 <4` resolves one `nanoid@3.3.18` for both consumers.

Because that means the 5.x consumer is downgraded across a major, I verified it rather than assuming — all green:

- `bun run check`
- `bun run build`
- `bun run size` (size-limit is the 5.x consumer; all budgets still pass)
- `bun run site:build` and `bun run rdn:build` (the astro/postcss path)

## Commit 2 — extract-zip: an accepted exposure, not a fix

**Nothing about this vulnerability is resolved here.** The only thing that changes is whether the audit gate stops on it.

`extract-zip`'s **latest published version IS 2.0.1**, and the advisory covers `<=2.0.1`. There is nothing to float to, so no `overrides` floor can fix it. It is also not a stale lockfile:

- locked `@netlify/functions-dev` is `1.3.0`; latest published is `1.3.5` — and **1.3.5 still declares `extract-zip ^2.0.1`**
- bumping `@astrojs/netlify` 8.1.1 → 8.2.1 does not drop the path

All of that was checked against the registry, not assumed.

That is precisely the criterion the `audit` job already documents — `--ignore` is reserved for advisories where no patched release is usable — and it is the identical basis for the two `image-size` entries already suppressed.

**Residual risk, stated plainly.** The vulnerability remains present in the dependency tree. What bounds it:

```
apps/site (PRIVATE) → @astrojs/netlify → @netlify/vite-plugin
  → @netlify/dev → @netlify/functions-dev → extract-zip ^2.0.1
```

It is build/dev-time only, lives under the private `apps/site` workspace, and is in **no published package** (`@randsum/roller`, `@randsum/games`, `@randsum/cli`, `@randsum/mcp` are all clear — `extract-zip` appears beneath none of them in `bun.lock`). The advisory is a symlink path traversal during extraction, which requires an attacker-authored archive; nothing here unpacks contributor-supplied zips. That bounds the exposure — it does not eliminate it.

**Process followed:** added to `osv-scanner.toml` **first**, as that file explicitly mandates ("Add here first, then there"), with the justification and a re-evaluation **condition rather than a date** — *re-check when `@netlify/functions-dev` drops the `extract-zip` dependency, or when extract-zip publishes above 2.0.1*. Then added to **all three** sync points (`ci.yml`, `security.yml`, `lefthook.yml`), since a suppression present in two of three makes local and CI disagree with no signal about which is authoritative.

**Not a randsum quirk.** The same advisory, with the same null patched version, is blocking the audit gate in the Binfinite repo through the same Netlify dev toolchain (alongside two likewise-unfixable `image-size` advisories). This is a portfolio-wide upstream problem, which makes the re-evaluation condition worth checking for more than this repo.

---

## Commit 3 — the three `sca` findings: real fixes, at a lower severity floor

All three have **published fixes**, so none was a suppression candidate. `osv-scanner.toml`'s rule turns on *no fix existing*; that is what separates this commit from commit 2 despite both touching the same gate.

| Advisory | Package | At | Fixed in | Severity |
|---|---|---|---|---|
| `GHSA-hp3v-mfqw-h74c` | `@astrojs/netlify` | 8.1.1 | **8.1.2** | Low |
| `GHSA-frvp-7c67-39w9` | `@hono/node-server` | 1.19.14 | **1.19.15** | Medium |
| `GHSA-4g3v-8h47-v7g6` | `astro` | 7.0.6 | **7.1.0** | Medium |

**Where each enters the tree**, established rather than assumed:

- **`@astrojs/netlify`** — direct dependency of `apps/site`. Bumped at the dependency.
- **`astro`** — direct dependency of **both** `apps/site` and `apps/rdn`; bumped in lockstep, since Bun gives them one resolution regardless.
- **`@hono/node-server`** — **not** a direct dependency and not an obvious randsum one. It arrives via `@modelcontextprotocol/sdk@1.29.0`, which declares `"@hono/node-server": "^1.19.9"`. That makes it the one of the three sitting under a **published** package (`@randsum/mcp`) rather than under the private `apps/*` — the opposite of the extract-zip situation, and a reason to fix rather than accept it even at Medium.

So the two direct dependencies moved at the dependency itself, and only the genuinely transitive one got an `overrides` floor — `">=1.19.15 <2"`, resolving to 1.19.17. A floor on a direct dependency would just be hiding a bump. The `<2` bound is deliberate: 2.x exists (and is separately affected below 2.0.5), while the SDK asks for `^1`.

**`astro` 7.0.6 → 7.1.0 is a MINOR bump, so it was verified, not assumed** — and it came back clean:

- `astro check` — **0 errors** in both apps (`apps/site` 44 files, `apps/rdn` 23 files)
- `bun run site:build` and `bun run rdn:build` — both exit 0
- `bun run check` (the full workspace suite, which runs build + check + format + lint + test per package) — exit 0
- No API surface changed in either app; the diff is three version strings and the lockfile

## Commit 4 — the local `sca` mirror could not pass from a worktree

Not an advisory fix. `scripts/sca-scan.sh` ran `--recursive ./`, and OSV-Scanner's directory walk honours `.gitignore` — where line 106 ignores `.claude/worktrees/`, which is exactly where Claude Code puts agent worktrees. Run from one, the walk visits 1 directory, makes **0 Extract calls**, prints `No package sources found` and exits **128**. That is a tooling outcome wearing the costume of a finding, on the one step whose value is being believed when it fails.

It now scans `bun.lock` directly, which is immune to `.gitignore` and loses no coverage: `bun.lock` is the only package source `git ls-files` turns up, so it is what the recursive walk resolves to in a normal checkout anyway. CI keeps `--recursive ./` — it runs on a clean checkout with no worktrees.

Two comments were corrected alongside the fix (in `ci.yml` and `osv-scanner.toml`), both of which named `@hono/node-server` as a standing finding that this PR removes.

---

## Verification

- `bun audit --audit-level=high` with the four ignores → **exit 0, no findings**
- `osv-scanner` 2.5.0 against `osv-scanner.toml` → **"No issues found"**, with the four documented suppressions filtered as intended and nothing else reported
- All four GHSA ids present in `osv-scanner.toml` and in each of the three sync points (verified 4/4/4, no drift)
- `bun install --frozen-lockfile` → no changes (lockfile agrees with every manifest)
- `bun run check` → exit 0; `bun run site:build` / `bun run rdn:build` → exit 0
- All three advisories confirmed against the OSV API directly, including their fixed versions
- `actionlint` clean on both workflow files; `osv-scanner.toml` parses
- Pushed **without** `--no-verify` — every `lefthook` pre-push step green, `audit` and `sca` included

Once this lands, rebasing the open PRs should turn them green.

