### PR TITLE
fix(discord-bot): make the gateway connection observable

### DIFF
--- a/apps/DEPLOY.md
+++ b/apps/DEPLOY.md
@@ -118,23 +118,43 @@ the first two need no Render access at all.
    `curl -sS https://registry.npmjs.org/@randsum/roller/latest` for the packages. "Randsum is
    down" is most often only one of these four.
 
-3. **Read the logs.** Render dashboard → `randsum-discord-bot` → **Logs**, or the `render` MCP
-   server (`.mcp.json`). The bot logs one JSON line per lifecycle event, so grep for the boot
-   sequence: `errorTracker.init` → `bot.connecting` → `login.retry` → `bot.login_succeeded` →
-   `bot.ready` → `commands.sync.*`. Where it stops tells you which failure this is:
+3. **Check the heartbeat first — it answers "is it connected?" directly.** Every
+   `metrics.flush` line (one per 5 minutes) embeds the gateway snapshot:
 
-   | Last line seen                     | Meaning                                                       |
-   | ---------------------------------- | ------------------------------------------------------------- |
+   ```
+   "gateway":{"status":"ready","connected":true,"forMs":812344,"disconnects":0,"resumes":0}
+   ```
+
+   Grep the logs for `'"connected":false'`. A hit is an outage, with `status` and `forMs`
+   saying which kind and for how long. **This is the fastest signal available and it should be
+   your first look** — it needs no correlation across lines.
+
+4. **Read the boot sequence.** Render dashboard → `randsum-discord-bot` → **Logs**, or the
+   `render` MCP server (`.mcp.json`). One JSON line per lifecycle event:
+   `errorTracker.init` → `bot.connecting` → `gateway.connecting` → `bot.login_succeeded`
+   (with `elapsedMs`) → `gateway.ready` → `commands.sync.*` → `bot.ready`. Where it stops tells
+   you which failure this is:
+
+   | Last line seen                      | Meaning                                                       |
+   | ----------------------------------- | ------------------------------------------------------------- |
    | `login.retry` ×5 then `login.failed`| Bad/revoked `DISCORD_TOKEN` → exit 1 → Render restart loop. Rotate the token (below). |
-   | `bot.ready`, then silence          | Connected and healthy; the problem is command registration or a specific command. |
-   | `commands.sync.failed`             | Registry desync only. The bot still serves its previous command list. |
-   | nothing at all                     | Service suspended, or the deploy never started. Check Render **Events**. |
+   | `bot.connecting` then nothing       | `client.login()` is hung — **not** a rejection, so `loginWithBackoff` never fires. Usually Discord throttling session starts. `gateway.stalled` fires after 5 min. |
+   | `gateway.disconnected` / `gateway.reconnecting` | WebSocket dropped. Process is alive and Render shows green; the bot is offline in Discord. |
+   | `bot.ready`, then silence           | Connected and healthy; the problem is command registration or a specific command. |
+   | `commands.sync.failed`              | Registry desync only. The bot still serves its previous command list. |
+   | nothing at all                      | Service suspended, or the deploy never started. Check Render **Events**. |
 
    Note the login path is a **crash loop by design**: five backed-off attempts, then `exit(1)`
    so a persistent auth failure surfaces to the platform rather than sitting in a fake-healthy
    process. Repeated restart events in Render with `login.failed` in each is the signature.
 
-4. **Check Sentry.** Only meaningful if the run logged `errorTracker.init … enabled: true`.
+   > **A green Render dashboard does not mean a connected bot.** Render only knows the process
+   > is alive. On 2026-08-18 the bot was offline while every Render signal — build, deploy,
+   > events, service status — was `succeeded`, and the logs showed nothing but identical
+   > `metrics.flush` heartbeats. The gateway fields above exist so that is never again
+   > indistinguishable from health; do not conclude "the bot is fine" from Render state alone.
+
+5. **Check Sentry.** Only meaningful if the run logged `errorTracker.init … enabled: true`.
    `SENTRY_DSN` is optional and unset by default — see the caveat under *Deploy* above.
 
 ### Restart

--- a/apps/discord-bot/CLAUDE.md
+++ b/apps/discord-bot/CLAUDE.md
@@ -37,6 +37,7 @@ apps/discord-bot/
       metrics.ts         # Lightweight metrics counters
       errorTracker.ts    # Error capture/reporting
       loginWithBackoff.ts # Gateway login with retry/backoff
+      gateway.ts         # Shard lifecycle logging, liveness snapshot, stall watchdog
       syncCommands.ts    # Startup reconciliation of Discord's registered commands
 ```
 
@@ -65,6 +66,35 @@ Set these before running:
 | `SENTRY_DSN`        | No       | When set, captured exceptions are delivered to Sentry (see below)           |
 
 `config.ts` throws at startup if `DISCORD_TOKEN` or `DISCORD_CLIENT_ID` are missing.
+
+## Gateway Observability
+
+A Discord worker has no inbound URL, so "is it up?" is answerable only from what it logs — and
+before `src/utils/gateway.ts` existed, it logged nothing about its connection. `index.ts`
+registered `ClientReady`, `InteractionCreate`, `GuildCreate` and `client.on('error')`, none of
+which fire on a shard disconnect. A dropped WebSocket therefore left the process alive, the
+5-minute `metrics.flush` heartbeat ticking, and Render reporting a healthy worker, while the bot
+was offline in Discord.
+
+Three pieces close that:
+
+- **Every transition is logged.** `registerGatewayLogging(client)` wires `ShardReady`,
+  `ShardResume`, `ShardReconnecting`, `ShardDisconnect` and `ShardError` to `gateway.*` lines
+  carrying shard id, close code, and how long the previous status held.
+- **The heartbeat carries liveness.** `metrics.flush` embeds `gatewaySnapshot()`
+  (`status`, `connected`, `forMs`, `disconnects`, `resumes`). This is the load-bearing part: a
+  heartbeat that proves only "the event loop is turning" is *worse* than none, because it reads
+  as health. Grep `'"connected":false'` to find an outage.
+- **A stall is reported once.** `startGatewayWatchdog()` runs before login and captures an
+  exception if the connection sits off `ready` past five minutes. Starting it *before* login is
+  deliberate — the failure it exists to catch is a login that never returns, which
+  `loginWithBackoff` cannot see because that only logs when a call *rejects*.
+
+It deliberately **does not auto-restart** a stalled connection. Discord throttles session starts,
+so restarting into a throttle deepens the outage; the watchdog escalates and a human decides.
+
+> On 2026-08-18 `client.login()` hung for a full hour between `bot.connecting` and
+> `bot.login_succeeded` with zero log output. `bot.login_succeeded` now records `elapsedMs`.
 
 ## Error Tracking
 

--- a/apps/discord-bot/__tests__/utils/gateway.test.ts
+++ b/apps/discord-bot/__tests__/utils/gateway.test.ts
@@ -1,0 +1,135 @@
+/**
+ * Covers gateway observability.
+ *
+ * The behaviour under test is the one whose absence caused the 2026-08-18
+ * outage: a connection that is not `ready` has to be *visible*, both in the
+ * transition log and in the periodic heartbeat. A test that only asserted
+ * "ready works" would have passed on the broken code too.
+ */
+import { describe, expect, test } from 'bun:test'
+import type { GatewayEvent, GatewaySnapshot } from '../../src/utils/gateway.js'
+
+interface GatewayModule {
+  readonly recordGatewayEvent: (event: GatewayEvent, fields?: Record<string, unknown>) => void
+  readonly gatewaySnapshot: () => GatewaySnapshot
+  readonly checkGatewayHealth: (thresholdMs?: number) => void
+}
+
+/** Module-level connection state, so each case gets its own instance. */
+async function loadGateway(): Promise<GatewayModule> {
+  const suffix = Math.random().toString(36).slice(2)
+  return await import(`../../src/utils/gateway.js?case=${suffix}`)
+}
+
+describe('gateway state', () => {
+  test('starts as connecting, not as connected', async () => {
+    const gw = await loadGateway()
+    const snap = gw.gatewaySnapshot()
+
+    // The pre-fix default was effectively "assume healthy" — nothing tracked
+    // state at all, so nothing could report a bad one.
+    expect(snap.status).toBe('connecting')
+    expect(snap.connected).toBe(false)
+  })
+
+  test('a disconnect is reflected in the snapshot the heartbeat reads', async () => {
+    const gw = await loadGateway()
+    gw.recordGatewayEvent('ready', { shardId: 0 })
+    expect(gw.gatewaySnapshot().connected).toBe(true)
+
+    gw.recordGatewayEvent('disconnected', { shardId: 0, code: 1006 })
+
+    const snap = gw.gatewaySnapshot()
+    expect(snap.status).toBe('disconnected')
+    expect(snap.connected).toBe(false)
+    expect(snap.disconnects).toBe(1)
+  })
+
+  test('resume returns to ready and is counted separately from a fresh ready', async () => {
+    const gw = await loadGateway()
+    gw.recordGatewayEvent('disconnected')
+    gw.recordGatewayEvent('reconnecting')
+    gw.recordGatewayEvent('resumed', { replayedEvents: 4 })
+
+    const snap = gw.gatewaySnapshot()
+    expect(snap.status).toBe('ready')
+    expect(snap.connected).toBe(true)
+    expect(snap.resumes).toBe(1)
+  })
+
+  test('reconnecting is not treated as connected', async () => {
+    const gw = await loadGateway()
+    gw.recordGatewayEvent('reconnecting')
+
+    expect(gw.gatewaySnapshot().connected).toBe(false)
+  })
+})
+
+describe('gateway watchdog', () => {
+  test('reports a connection stuck off ready past the threshold', async () => {
+    const gw = await loadGateway()
+    gw.recordGatewayEvent('connecting')
+
+    // Threshold 0 stands in for elapsed time without a fake clock.
+    expect(() => {
+      gw.checkGatewayHealth(0)
+    }).not.toThrow()
+    expect(gw.gatewaySnapshot().status).toBe('connecting')
+  })
+
+  test('stays quiet while the connection is ready', async () => {
+    const gw = await loadGateway()
+    gw.recordGatewayEvent('ready')
+
+    // A ready connection must never alarm, no matter how long it has held.
+    gw.checkGatewayHealth(0)
+    expect(gw.gatewaySnapshot().connected).toBe(true)
+  })
+
+  test('a stall alarms once, then recovery re-arms it', async () => {
+    const gw = await loadGateway()
+    gw.recordGatewayEvent('disconnected')
+
+    gw.checkGatewayHealth(0)
+    gw.checkGatewayHealth(0) // second call must be a no-op — one page per stall
+    gw.recordGatewayEvent('ready')
+    expect(gw.gatewaySnapshot().connected).toBe(true)
+
+    // Re-armed: a fresh stall is reportable again.
+    gw.recordGatewayEvent('disconnected')
+    expect(() => {
+      gw.checkGatewayHealth(0)
+    }).not.toThrow()
+    expect(gw.gatewaySnapshot().disconnects).toBe(2)
+  })
+})
+
+describe('metrics heartbeat', () => {
+  test('carries gateway state, so a heartbeat is not mistaken for health', async () => {
+    // Both imported unsuffixed on purpose: metrics.js imports gateway.js by its
+    // plain specifier, so a cache-busted gateway would be a *different* module
+    // instance and the two would not share state. No other case touches the
+    // unsuffixed instance, so this one still starts clean.
+    const gw: GatewayModule = await import('../../src/utils/gateway.js')
+    const metrics: { flushMetrics: () => void } = await import('../../src/utils/metrics.js')
+
+    gw.recordGatewayEvent('disconnected')
+
+    const lines: string[] = []
+    const original = console.warn
+    console.warn = (line: string) => {
+      lines.push(line)
+    }
+    try {
+      metrics.flushMetrics()
+    } finally {
+      console.warn = original
+    }
+
+    const flush = lines.map(l => JSON.parse(l)).find(l => l.msg === 'metrics.flush')
+    expect(flush).toBeDefined()
+    // Pre-fix, this line was byte-identical whether or not the bot was connected.
+    expect(flush.gateway.connected).toBe(false)
+    expect(flush.gateway.status).toBe('disconnected')
+  })
+})

--- a/apps/discord-bot/src/index.ts
+++ b/apps/discord-bot/src/index.ts
@@ -8,6 +8,12 @@ import { flushMetrics, startMetricsFlush, stopMetricsFlush } from './utils/metri
 import { captureException, flushErrorTracker, initErrorTracker } from './utils/errorTracker.js'
 import { loginWithBackoff } from './utils/loginWithBackoff.js'
 import { syncCommands } from './utils/syncCommands.js'
+import {
+  recordGatewayEvent,
+  registerGatewayLogging,
+  startGatewayWatchdog,
+  stopGatewayWatchdog
+} from './utils/gateway.js'
 
 // Import events
 import { interactionCreateHandler } from './events/interactionCreate.js'
@@ -53,6 +59,11 @@ client.on('error', error => {
   captureException(error, { phase: 'client.error' })
 })
 
+// Shard lifecycle. `client.on('error')` above does NOT cover this: shard errors
+// and disconnects are separate events, so without these a dropped WebSocket is
+// completely silent and the bot goes offline with nothing in the logs.
+registerGatewayLogging(client)
+
 process.on('unhandledRejection', error => {
   captureException(error, { phase: 'unhandledRejection' })
 })
@@ -66,6 +77,7 @@ function shutdown(signal: string): void {
   logger.info('bot.shutdown', { signal })
   flushMetrics()
   stopMetricsFlush()
+  stopGatewayWatchdog()
   void client.destroy()
   process.exit(0)
 }
@@ -81,9 +93,16 @@ process.on('SIGINT', () => {
 // boot does not immediately exit, and a misconfigured auth does not produce a
 // tight restart-crash loop under Render's auto-restart.
 logger.info('bot.connecting')
+recordGatewayEvent('connecting')
+// Started before login, not after: the failure this exists to catch is a login
+// that never returns. `loginWithBackoff` only logs when a call *rejects*, so a
+// hung `client.login()` produces no output at all — on 2026-08-18 that was a
+// silent hour between `bot.connecting` and `bot.login_succeeded`.
+startGatewayWatchdog()
+const loginStartedAt = Date.now()
 try {
   await loginWithBackoff(() => client.login(config.token))
-  logger.info('bot.login_succeeded')
+  logger.info('bot.login_succeeded', { elapsedMs: Date.now() - loginStartedAt })
 } catch (error) {
   captureException(error, { phase: 'login' })
   flushMetrics()

--- a/apps/discord-bot/src/utils/gateway.ts
+++ b/apps/discord-bot/src/utils/gateway.ts
@@ -1,0 +1,192 @@
+/**
+ * Gateway connection observability.
+ *
+ * The bot's liveness used to be unobservable. `index.ts` registered
+ * `ClientReady`, `InteractionCreate`, `GuildCreate` and `client.on('error')` —
+ * but nothing for the shard lifecycle. So a dropped WebSocket left the process
+ * alive, the 5-minute `metrics.flush` heartbeat ticking, and Render reporting a
+ * perfectly healthy worker, while the bot sat offline in Discord.
+ *
+ * This is not hypothetical. On 2026-08-18 `client.login()` hung for a full hour
+ * between `bot.connecting` and `bot.login_succeeded` without emitting one line:
+ * the hang was *inside* login, and `loginWithBackoff` only logs when a call
+ * rejects. The outage was invisible in Render, invisible in the logs, and
+ * visible only to people trying to use the bot.
+ *
+ * Two fixes here. Every gateway transition becomes a log line, and
+ * `gatewaySnapshot()` lets the heartbeat carry liveness instead of implying it.
+ * The second matters as much as the first: a heartbeat proving only "the event
+ * loop is turning" is worse than no heartbeat, because it reads as health while
+ * saying nothing about the connection.
+ *
+ * Deliberately **no auto-restart** on a stalled connection. Discord throttles
+ * session starts, and an hour-long login is consistent with exactly that, so a
+ * watchdog that exited would deepen the hole it was trying to climb out of.
+ * This escalates to the error tracker and leaves the decision to a human.
+ */
+import { Events } from './discord.js'
+import type { Client } from './discord.js'
+import type { LogFields } from './logger.js'
+import { logger } from './logger.js'
+import { captureException } from './errorTracker.js'
+
+export type GatewayStatus = 'connecting' | 'ready' | 'reconnecting' | 'disconnected'
+
+/** What happened, as opposed to the status it puts us in (`resumed` → ready). */
+export type GatewayEvent = 'connecting' | 'ready' | 'resumed' | 'reconnecting' | 'disconnected'
+
+const STATUS_FOR: Readonly<Record<GatewayEvent, GatewayStatus>> = {
+  connecting: 'connecting',
+  ready: 'ready',
+  resumed: 'ready',
+  reconnecting: 'reconnecting',
+  disconnected: 'disconnected'
+}
+
+const LEVEL_FOR: Readonly<Record<GatewayEvent, 'info' | 'warn'>> = {
+  connecting: 'info',
+  ready: 'info',
+  resumed: 'info',
+  reconnecting: 'warn',
+  disconnected: 'warn'
+}
+
+/** Anything other than `ready` for longer than this is reported, once. */
+const STALL_THRESHOLD_MS = 5 * 60 * 1000
+const WATCHDOG_INTERVAL_MS = 60 * 1000
+
+const state: {
+  status: GatewayStatus
+  changedAt: number
+  disconnects: number
+  resumes: number
+  alarmed: boolean
+} = {
+  status: 'connecting',
+  changedAt: Date.now(),
+  disconnects: 0,
+  resumes: 0,
+  alarmed: false
+}
+
+export interface GatewaySnapshot {
+  readonly status: GatewayStatus
+  readonly connected: boolean
+  /** How long the current status has held — the number that exposes a stall. */
+  readonly forMs: number
+  readonly disconnects: number
+  readonly resumes: number
+}
+
+export function gatewaySnapshot(): GatewaySnapshot {
+  return {
+    status: state.status,
+    connected: state.status === 'ready',
+    forMs: Date.now() - state.changedAt,
+    disconnects: state.disconnects,
+    resumes: state.resumes
+  }
+}
+
+/**
+ * Record a gateway transition and log it. `fields` carries event-specific
+ * detail (shard id, close code) straight into the structured line.
+ */
+export function recordGatewayEvent(event: GatewayEvent, fields: LogFields = {}): void {
+  const previous = state.status
+  const heldMs = Date.now() - state.changedAt
+  const next = STATUS_FOR[event]
+
+  if (event === 'disconnected') state.disconnects += 1
+  if (event === 'resumed') state.resumes += 1
+
+  // Whether this transition ends a stall we already reported — captured before
+  // the flag is cleared, so recovery is logged exactly once.
+  const recovered = next === 'ready' && state.alarmed
+
+  state.status = next
+  state.changedAt = Date.now()
+  if (next === 'ready') state.alarmed = false
+
+  logger[LEVEL_FOR[event]](`gateway.${event}`, {
+    ...fields,
+    previous,
+    previousHeldMs: heldMs
+  })
+
+  if (recovered) {
+    logger.info('gateway.recovered', { after: previous, downMs: heldMs })
+  }
+}
+
+/**
+ * Report a connection stuck off `ready`. Fires once per stall — a five-minute
+ * outage should page you once, not every minute until someone looks.
+ */
+export function checkGatewayHealth(thresholdMs: number = STALL_THRESHOLD_MS): void {
+  if (state.status === 'ready' || state.alarmed) return
+
+  const stalledMs = Date.now() - state.changedAt
+  if (stalledMs < thresholdMs) return
+
+  state.alarmed = true
+  logger.error('gateway.stalled', { status: state.status, stalledMs })
+  captureException(
+    new Error(`Discord gateway stalled in "${state.status}" for ${Math.round(stalledMs / 1000)}s`),
+    { phase: 'gateway.stalled', status: state.status, stalledMs }
+  )
+}
+
+const watchdogState: { timer: ReturnType<typeof setInterval> | undefined } = {
+  timer: undefined
+}
+
+export function startGatewayWatchdog(intervalMs: number = WATCHDOG_INTERVAL_MS): void {
+  if (watchdogState.timer !== undefined) return
+  const timer = setInterval(() => {
+    checkGatewayHealth()
+  }, intervalMs)
+  // Never keep the process alive just to watch a connection.
+  if (typeof timer.unref === 'function') {
+    timer.unref()
+  }
+  watchdogState.timer = timer
+}
+
+export function stopGatewayWatchdog(): void {
+  if (watchdogState.timer === undefined) return
+  clearInterval(watchdogState.timer)
+  watchdogState.timer = undefined
+}
+
+/**
+ * Wire discord.js's shard lifecycle to the recorder. Thin on purpose — the
+ * state machine above is what carries behaviour, and it is testable without a
+ * gateway.
+ */
+export function registerGatewayLogging(client: Client): void {
+  client.on(Events.ShardReady, shardId => {
+    recordGatewayEvent('ready', { shardId })
+  })
+
+  client.on(Events.ShardResume, (shardId, replayedEvents) => {
+    recordGatewayEvent('resumed', { shardId, replayedEvents })
+  })
+
+  client.on(Events.ShardReconnecting, shardId => {
+    recordGatewayEvent('reconnecting', { shardId })
+  })
+
+  client.on(Events.ShardDisconnect, (closeEvent, shardId) => {
+    recordGatewayEvent('disconnected', {
+      shardId,
+      code: closeEvent.code,
+      reason: closeEvent.reason
+    })
+  })
+
+  client.on(Events.ShardError, (error, shardId) => {
+    logger.error('gateway.shard_error', { shardId })
+    captureException(error, { phase: 'gateway.shard_error', shardId })
+  })
+}

--- a/apps/discord-bot/src/utils/metrics.ts
+++ b/apps/discord-bot/src/utils/metrics.ts
@@ -9,6 +9,7 @@
  * No external metrics dependency (no prom-client/StatsD) — a counts log line is
  * the agreed baseline per the audit acceptance criteria.
  */
+import { gatewaySnapshot } from './gateway.js'
 import { logger } from './logger.js'
 
 const invocations = new Map<string, number>()
@@ -55,7 +56,12 @@ export function flushMetrics(): void {
     invocations: snap.invocations,
     errors: snap.errors,
     totalInvocations: snap.totalInvocations,
-    totalErrors: snap.totalErrors
+    totalErrors: snap.totalErrors,
+    // The heartbeat has to say whether the bot is *connected*, not merely that
+    // the event loop is turning. Without this, a disconnected bot emits a line
+    // identical to a healthy one every five minutes — which is exactly how the
+    // 2026-08-18 outage stayed invisible in Render for an hour.
+    gateway: gatewaySnapshot()
   })
 }
 


### PR DESCRIPTION
## The incident

The bot was down. Every signal Render had said it was fine:

| Signal | Reported |
| --- | --- |
| Build / deploy | `succeeded` |
| `server_failed` events | **none**, across 7 days |
| Service status | live |
| Logs | identical `metrics.flush` heartbeats, every 5 min |

All of that was **also** consistent with a completely disconnected bot, because none of it was measuring the connection.

The starkest symptom, from the log tail:

```
02:18:29  bot.connecting
   … 60 minutes of metrics.flush, nothing else …
03:18:51  bot.login_succeeded
03:18:52  bot.ready   tag: RANDSUM.io#8392  guilds: 15
```

`client.login()` hung for **a full hour** and emitted not one line. There are zero `login.retry` warnings in that window — the hang was *inside* login, and `loginWithBackoff` only logs when a call **rejects**. An hour-long outage with no log line and no failed health check.

## Two gaps caused the invisibility

**1. No shard lifecycle handlers.** `index.ts` registered `ClientReady`, `InteractionCreate`, `GuildCreate` and `client.on('error')`. None of those fire on a shard disconnect — shard errors and disconnects are separate events in discord.js. So a dropped WebSocket was silent, the process stayed alive, and Render stayed green.

**2. The heartbeat was a false liveness signal.** `metrics.flush` is a bare `setInterval`. It proves the event loop is turning and nothing more. That's worse than no heartbeat: it *reads* as health while saying nothing about the connection. Hundreds of those lines are exactly what the outage looked like.

## The fix

- **`utils/gateway.ts`** wires `ShardReady` / `ShardResume` / `ShardReconnecting` / `ShardDisconnect` / `ShardError` to `gateway.*` log lines carrying shard id, close code, and how long the previous status held.
- **`metrics.flush` embeds `gatewaySnapshot()`.** The heartbeat now carries liveness:
  ```
  "gateway":{"status":"connecting","connected":false,"forMs":15652,"disconnects":0,"resumes":0}
  ```
  Grepping `'"connected":false'` finds an outage directly — no cross-line correlation.
- **A stall watchdog** reports a connection stuck off `ready` past 5 minutes, once per stall (a 5-minute outage should page you once, not 5 times). Started **before** login, because the failure it exists to catch is a login that never returns.
- **`bot.login_succeeded` records `elapsedMs`** — alone, that would have made the silent hour obvious.

**Deliberately no auto-restart on a stall.** Discord throttles session starts, and an hour-long login is consistent with exactly that — a watchdog that exited would deepen the hole it was climbing out of. It escalates to the error tracker and lets a human decide.

## Design note

The state machine is separated from the discord.js wiring, so it's testable without a gateway. The tests assert the **not-ready** paths specifically — a suite that only checked "ready works" would have passed against the broken code too, which is how this gap survived in the first place.

## Also

Corrects the triage runbook I added in #1214, which would have **misread this very incident**: it treated a green Render dashboard as evidence of health. Render only knows the process is alive. The runbook now leads with the heartbeat's `connected` field and carries an explicit warning against concluding "the bot is fine" from Render state alone.

## Test plan

- `bun run --filter @randsum/discord-bot check` → exit 0
- 118 tests pass (8 new)
- `bun run knip` → clean
- Booted the built worker under `node` and confirmed the new lines land: `gateway.connecting` on startup, and the heartbeat reporting `"connected":false` while disconnected

> Note: pre-push `sca` excluded — `osv-scanner` is a mise shim with no version pinned locally and Docker isn't running. No dependency changes in this branch; CI's `sca` job still gates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Qeum9i6jZtAHoziAZFHSsH