### PR TITLE
docs: link the Butter Stack from the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,8 @@
 
 **[RDN v0.9.0 Level 4 (Full) Conformant](https://notation.randsum.dev)** — implements the complete RANDSUM Dice Notation Specification
 
+Built on **[the Butter Stack](https://alxjrvs.github.io/butter/)** — Bun · Unified workspace · TypeScript · TanStack · Edge-deployed · React.
+
 ## 📦 Monorepo Structure
 
 This repository contains multiple packages and applications for dice rolling and tabletop RPG mechanics:


### PR DESCRIPTION
Names the stack this repo is built on and points at the page that describes it: <https://alxjrvs.github.io/butter/>.

One line under the badge block, beside the RDN conformance line.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YB4dTHRMqHCCHGEEVs6QBA