### PR TITLE
feat(rdn): Cloudflare Workers deploy for notation.randsum.dev

### DIFF
--- a/.github/workflows/deploy-cloudflare.yml
+++ b/.github/workflows/deploy-cloudflare.yml
@@ -1,0 +1,48 @@
+# Deploy static sites to Cloudflare Workers on merge to main.
+#
+# Netlify deploys itself from its own git integration, which is why this repo
+# has never had a deploy job. Cloudflare has no equivalent — Workers Builds
+# exists, but its monorepo handling has a known flakiness report for workspace
+# dependency resolution and nothing authoritative for Bun, and this repo has
+# cross-package build ordering (roller -> rdn) that CI already sequences
+# correctly. So deployment lives here, where the build is already known-good.
+#
+# Path-filtered per site rather than deploying everything on every merge, which
+# is the same economy the netlify.toml `ignore` predicates were buying.
+name: Deploy (Cloudflare)
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'apps/rdn/**'
+      - 'packages/roller/**'
+      - 'bun.lock'
+      - '.github/workflows/deploy-cloudflare.yml'
+
+permissions:
+  contents: read
+
+concurrency:
+  # Never let two deploys race to the same Worker. Not cancel-in-progress: a
+  # half-finished asset upload that gets cancelled is worse than a short queue.
+  group: deploy-cloudflare
+  cancel-in-progress: false
+
+jobs:
+  rdn:
+    name: notation.randsum.dev
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - uses: ./.github/actions/bun-setup
+
+      # rdn imports @randsum/roller via a workspace subpath export, so roller
+      # must be built first or the Astro build resolves nothing.
+      - name: Build
+        run: bun run --filter @randsum/roller --filter @randsum/rdn build
+
+      - name: Deploy
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+        run: bunx wrangler@4 deploy -c apps/rdn/wrangler.jsonc

--- a/apps/rdn/CLAUDE.md
+++ b/apps/rdn/CLAUDE.md
@@ -111,6 +111,13 @@ keeping the published JSON in sync with the source.
   `@astrojs/language-server`'s `getTsconfig`. Revisit when `@astrojs/check` ships a
   release whose peer range admits TypeScript 7.
 - Private app, never published to npm.
-- Deployed to Netlify (see `netlify.toml`).
+- **Deployed to both Netlify (`netlify.toml`) and Cloudflare Workers
+  (`wrangler.jsonc`) during the migration.** Netlify is still the live site —
+  DNS has not moved — and Cloudflare publishes alongside it until the cutover.
+  Cloudflare deploys from `.github/workflows/deploy-cloudflare.yml` on merge to
+  `main`, not from Workers Builds: rdn imports roller through a workspace
+  subpath export that has to be built first, and CI already sequences that.
+  No Astro adapter is involved — the site is `output: 'static'`, so Cloudflare
+  serves `dist/` directly through an assets binding with no Worker script.
 - Fonts: Inter (body) and JetBrains Mono (code/headings), via Astro's Google
   font provider (`astro.config.ts`).

--- a/apps/rdn/wrangler.jsonc
+++ b/apps/rdn/wrangler.jsonc
@@ -1,0 +1,25 @@
+{
+  // Cloudflare Workers deployment for notation.randsum.dev.
+  //
+  // This site is `output: 'static'` with no Astro adapter, so there is no Worker
+  // script at all — Cloudflare serves the built files directly from the assets
+  // binding. Requests to static assets are free and unbilled, and do not count
+  // against the Workers request quota.
+  //
+  // No adapter is added on purpose. `@astrojs/cloudflare` exists to run
+  // server-rendered routes, and this site has none; adding it would introduce a
+  // Worker script, a `wrangler` peer dependency, and an Astro version floor for
+  // no behavioural gain. See apps/site for the case that genuinely needs one.
+  "$schema": "node_modules/wrangler/config-schema.json",
+  "name": "randsum-rdn",
+  // Only matters once a Worker script exists; set now so adding one later does
+  // not silently pick up a different runtime baseline.
+  "compatibility_date": "2026-08-18",
+  "assets": {
+    "directory": "./dist",
+    // Serve Astro's own 404 page rather than Cloudflare's bare 404. Without
+    // this, unmatched routes return a blank platform error and the site's own
+    // styling and navigation are lost.
+    "not_found_handling": "404-page"
+  }
+}


### PR DESCRIPTION
**Phase 1 of the Cloudflare migration.** Nothing user-facing changes: DNS still points at Netlify, so this publishes *alongside* the live site rather than replacing it. The cutover is Phase 2.

`rdn` goes first deliberately — it's the lowest-stakes surface in the repo (pure static, no adapter, no server routes, one workspace dep), so its real job is proving the deploy path and CI wiring on something that can't break much.

## No Astro adapter, on purpose

`@astrojs/cloudflare` exists to run server-rendered routes, and this site has none. Adding it would introduce a Worker script, a `wrangler` peer dependency and an Astro version floor for zero behavioural gain.

`output: 'static'` + an assets binding is the entire deployment. Cloudflare serves `dist/` directly, and **requests to static assets are free, unbilled, and don't count against the Workers request quota**. `apps/site` is the case that genuinely needs an adapter; this isn't.

`not_found_handling: "404-page"` is set so unmatched routes get Astro's own 404 rather than Cloudflare's bare platform error — without it, every typo'd URL silently loses the site's styling and navigation.

## Why the deploy job lives here, not in Workers Builds

This repo has never had a deploy job, because Netlify deploys itself from its own git integration. Cloudflare's equivalent (Workers Builds) has a known flakiness report for workspace dependency resolution in monorepos and nothing authoritative for Bun — and `rdn` imports `@randsum/roller` through a workspace subpath export that must be built first or the Astro build resolves nothing.

CI already sequences that correctly, so deployment goes where the build is already known-good. Path-filtered per site, which buys back the same economy the `netlify.toml` `ignore` predicates were providing.

## Verified

Deployed by hand: **all 13 assets uploaded, `randsum-rdn` Worker created.**

## ⚠️ Two account steps before this can actually serve

Neither is code, and neither blocks merging:

1. **Register a `workers.dev` subdomain** — the account has none, so the Worker currently has no URL at all. One-time, interactive: https://dash.cloudflare.com/f5f08e7e86ab8c183e381d4504bf8ba5/workers/onboarding
2. **Add a `CLOUDFLARE_API_TOKEN` repo secret** — needs `Workers Scripts: Edit`. Until it exists, the workflow will run and fail on merge. Create it in the Cloudflare dashboard, then `gh secret set CLOUDFLARE_API_TOKEN`.

Until (1), there's no URL to smoke-test against before Phase 2 moves DNS — which is a real loss of safety, so it's worth doing before the cutover rather than after.

## Test plan

- YAML validated; `workflow-lint` (actionlint + zizmor) runs on this PR
- Action SHA-pinned to match the rest of the repo's workflows
- `concurrency` is `cancel-in-progress: false` — a cancelled half-finished asset upload is worse than a short queue

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Qeum9i6jZtAHoziAZFHSsH