### PR TITLE
fix(ci): skip Cloudflare deploy when the API token is absent

### DIFF
--- a/.github/workflows/deploy-cloudflare.yml
+++ b/.github/workflows/deploy-cloudflare.yml
@@ -9,6 +9,13 @@
 #
 # Path-filtered per site rather than deploying everything on every merge, which
 # is the same economy the netlify.toml `ignore` predicates were buying.
+#
+# Both jobs SKIP rather than fail when CLOUDFLARE_API_TOKEN is absent. That is
+# the state of the world until the secret is added, and a workflow that fails
+# red on every merge for a known, documented, expected reason is worse than one
+# that does nothing: it trains people to ignore a failing check, and the next
+# real failure hides inside the noise. Adding the secret enables deploys with no
+# further change here.
 name: Deploy (Cloudflare)
 
 on:
@@ -46,7 +53,13 @@ jobs:
       - name: Deploy
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
-        run: bunx wrangler@4 deploy -c apps/rdn/wrangler.jsonc
+        run: |
+          if [ -z "$CLOUDFLARE_API_TOKEN" ]; then
+            echo "::notice::CLOUDFLARE_API_TOKEN is not set — skipping deploy."
+            echo "Add the secret to enable Cloudflare deploys. Netlify is unaffected."
+            exit 0
+          fi
+          bunx wrangler@4 deploy -c apps/rdn/wrangler.jsonc
 
   site:
     name: randsum.dev
@@ -74,4 +87,10 @@ jobs:
       - name: Deploy
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
-        run: bunx wrangler@4 deploy -c apps/site/dist/server/wrangler.json
+        run: |
+          if [ -z "$CLOUDFLARE_API_TOKEN" ]; then
+            echo "::notice::CLOUDFLARE_API_TOKEN is not set — skipping deploy."
+            echo "Add the secret to enable Cloudflare deploys. Netlify is unaffected."
+            exit 0
+          fi
+          bunx wrangler@4 deploy -c apps/site/dist/server/wrangler.json


### PR DESCRIPTION
The deploy workflow added in #1218 **failed on merge to main** — `CLOUDFLARE_API_TOKEN` doesn't exist yet — and would keep failing on every merge until it does.

A check that is red for a known, documented, expected reason is worse than one that does nothing. It trains people to ignore a failing check, and the next *real* failure hides inside the noise. This repo's own conventions make that argument elsewhere: an advisory check that can never meaningfully pass "teaches people to skim the whole checks list."

Both jobs now skip with a `::notice::` instead, and begin deploying the moment the secret is added — no further change needed here.

```
::notice::CLOUDFLARE_API_TOKEN is not set — skipping deploy.
Add the secret to enable Cloudflare deploys. Netlify is unaffected.
```

Netlify continues to serve both sites regardless; nothing about this affects the live deploys.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Qeum9i6jZtAHoziAZFHSsH