### PR TITLE
refactor(discord-bot): separate command logic from the gateway transport

### DIFF
--- a/apps/discord-bot/__tests__/commands/lib/context.test.ts
+++ b/apps/discord-bot/__tests__/commands/lib/context.test.ts
@@ -1,0 +1,66 @@
+/**
+ * Covers the transport-agnostic option adapter.
+ *
+ * These tests exist because `optionsFromPayload` is the piece that has to
+ * behave identically to discord.js's accessors without being discord.js. A
+ * divergence here would show up as a command silently reading `null` for an
+ * option the user actually supplied — which looks like a game-logic bug, not a
+ * transport bug, and would be hunted for in entirely the wrong file.
+ */
+import { describe, expect, test } from 'bun:test'
+import { optionsFromPayload } from '../../../src/commands/lib/context.js'
+
+describe('optionsFromPayload', () => {
+  test('reads values by name and type', () => {
+    const options = optionsFromPayload([
+      { name: 'notation', value: '4d6L' },
+      { name: 'modifier', value: 3 },
+      { name: 'hidden', value: true }
+    ])
+
+    expect(options.getString('notation')).toBe('4d6L')
+    expect(options.getInteger('modifier')).toBe(3)
+    expect(options.getBoolean('hidden')).toBe(true)
+  })
+
+  test('returns null for an absent option', () => {
+    const options = optionsFromPayload([{ name: 'notation', value: '2d20' }])
+
+    expect(options.getString('missing')).toBeNull()
+    expect(options.getInteger('missing')).toBeNull()
+    expect(options.getBoolean('missing')).toBeNull()
+  })
+
+  test('returns null when the option exists but is the wrong type', () => {
+    // Discord's own validation makes this near-impossible, but reading an
+    // integer as a string must not silently coerce — a stringified number
+    // flowing into the roller is exactly the kind of bug that survives review.
+    const options = optionsFromPayload([{ name: 'modifier', value: '3' }])
+
+    expect(options.getInteger('modifier')).toBeNull()
+    expect(options.getString('modifier')).toBe('3')
+  })
+
+  test('handles a missing options array', () => {
+    // Discord omits `options` entirely for a command invoked with no arguments.
+    const options = optionsFromPayload(undefined)
+
+    expect(options.getString('anything')).toBeNull()
+  })
+
+  test('a false boolean is returned, not treated as absent', () => {
+    // The bug this pins: `?? false` and `=== null` behave differently, and
+    // `hidden: false` must not be mistaken for "not supplied".
+    const options = optionsFromPayload([{ name: 'hidden', value: false }])
+
+    expect(options.getBoolean('hidden')).toBe(false)
+    expect(options.getBoolean('hidden')).not.toBeNull()
+  })
+
+  test('a zero integer is returned, not treated as absent', () => {
+    // `/blades` accepts 0 dice as a real, meaningful value.
+    const options = optionsFromPayload([{ name: 'dice', value: 0 }])
+
+    expect(options.getInteger('dice')).toBe(0)
+  })
+})

--- a/apps/discord-bot/src/commands/blades.ts
+++ b/apps/discord-bot/src/commands/blades.ts
@@ -2,11 +2,11 @@ import { EmbedBuilder, SlashCommandBuilder } from '../utils/discord.js'
 import { roll } from '@randsum/games/blades'
 import { embedFooterDetails } from '../utils/constants.js'
 import { createGameCommand, getInitialRolls } from './lib/index.js'
-import type { ChatInputCommandInteraction } from '../utils/discord.js'
+import type { CommandContext } from './lib/index.js'
 import type { Command } from '../types.js'
 
-function buildBladesEmbed(interaction: ChatInputCommandInteraction): EmbedBuilder {
-  const dice = interaction.options.getInteger('dice', true)
+function buildBladesEmbed(context: CommandContext): EmbedBuilder {
+  const dice = context.options.getInteger('dice', true)
   const result = roll({ rating: dice })
 
   const initialRolls = getInitialRolls(result)

--- a/apps/discord-bot/src/commands/dh.ts
+++ b/apps/discord-bot/src/commands/dh.ts
@@ -2,17 +2,17 @@ import { EmbedBuilder, SlashCommandBuilder } from '../utils/discord.js'
 import { roll } from '@randsum/games/daggerheart'
 import { embedFooterDetails } from '../utils/constants.js'
 import { createGameCommand, formatSignedModifier } from './lib/index.js'
-import type { ChatInputCommandInteraction } from '../utils/discord.js'
+import type { CommandContext } from './lib/index.js'
 import type { Command } from '../types.js'
 
-function buildDhEmbed(interaction: ChatInputCommandInteraction): EmbedBuilder {
-  const modifier = interaction.options.getInteger('modifier') ?? 0
-  const rollingWith = interaction.options.getString('rolling_with') as
+function buildDhEmbed(context: CommandContext): EmbedBuilder {
+  const modifier = context.options.getInteger('modifier') ?? 0
+  const rollingWith = context.options.getString('rolling_with') as
     | 'Advantage'
     | 'Disadvantage'
     | null
-  const amplifyHope = interaction.options.getBoolean('amplify_hope') ?? false
-  const amplifyFear = interaction.options.getBoolean('amplify_fear') ?? false
+  const amplifyHope = context.options.getBoolean('amplify_hope') ?? false
+  const amplifyFear = context.options.getBoolean('amplify_fear') ?? false
 
   const result = roll({
     modifier,

--- a/apps/discord-bot/src/commands/fate.ts
+++ b/apps/discord-bot/src/commands/fate.ts
@@ -3,7 +3,7 @@ import { roll } from '@randsum/games/fate'
 import type { FateRollResult } from '@randsum/games/fate'
 import { embedFooterDetails } from '../utils/constants.js'
 import { createGameCommand, formatSignedModifier, getInitialRolls } from './lib/index.js'
-import type { ChatInputCommandInteraction } from '../utils/discord.js'
+import type { CommandContext } from './lib/index.js'
 import type { Command } from '../types.js'
 
 const SKILL_MIN = -2
@@ -33,8 +33,8 @@ function fateDieSymbol(die: number): string {
   return '▢'
 }
 
-function buildFateEmbed(interaction: ChatInputCommandInteraction): EmbedBuilder {
-  const rawSkill = interaction.options.getInteger('skill') ?? 0
+function buildFateEmbed(context: CommandContext): EmbedBuilder {
+  const rawSkill = context.options.getInteger('skill') ?? 0
   const skill = Math.max(SKILL_MIN, Math.min(SKILL_MAX, rawSkill))
 
   const result = roll({ modifier: skill })

--- a/apps/discord-bot/src/commands/fifth.ts
+++ b/apps/discord-bot/src/commands/fifth.ts
@@ -2,7 +2,7 @@ import { EmbedBuilder, SlashCommandBuilder } from '../utils/discord.js'
 import { roll } from '@randsum/games/fifth'
 import { embedFooterDetails } from '../utils/constants.js'
 import { createGameCommand, formatSignedModifier, getInitialRolls } from './lib/index.js'
-import type { ChatInputCommandInteraction } from '../utils/discord.js'
+import type { CommandContext } from './lib/index.js'
 import type { Command } from '../types.js'
 
 /**
@@ -26,9 +26,9 @@ function markKeptRolls(initialRolls: readonly number[], keptRolls: readonly numb
     .join(', ')
 }
 
-function buildFifthEmbed(interaction: ChatInputCommandInteraction): EmbedBuilder {
-  const modifier = interaction.options.getInteger('modifier') ?? 0
-  const rollingWith = interaction.options.getString('rolling_with') as
+function buildFifthEmbed(context: CommandContext): EmbedBuilder {
+  const modifier = context.options.getInteger('modifier') ?? 0
+  const rollingWith = context.options.getString('rolling_with') as
     | 'Advantage'
     | 'Disadvantage'
     | null

--- a/apps/discord-bot/src/commands/lib/context.ts
+++ b/apps/discord-bot/src/commands/lib/context.ts
@@ -1,0 +1,90 @@
+/**
+ * The transport-agnostic slice of an interaction.
+ *
+ * Every command's actual work — read some options, compute a roll, build an
+ * embed — needs almost nothing from discord.js. It needs three option getters
+ * and, in one case, the caller's display name. Everything else about
+ * `ChatInputCommandInteraction` is transport: a live gateway connection, a
+ * client, reply methods that write back over a socket.
+ *
+ * Naming that slice is what makes the bot portable. A gateway bot satisfies
+ * this interface from `interaction.options`; an HTTP-interactions Worker
+ * satisfies it by reading the raw JSON Discord POSTs. Neither knows about the
+ * other, and the command bodies know about neither.
+ *
+ * This is deliberately the *smallest* interface that covers current usage
+ * rather than a general-purpose wrapper. A wider surface would be easier to
+ * write against and much easier to accidentally couple to one transport again.
+ */
+
+/**
+ * Option accessors, matching the subset of discord.js's shape actually used.
+ *
+ * Overloaded rather than plain `=> T | null` so that `required: true` narrows to
+ * a non-null result, exactly as discord.js does. Without the overloads every
+ * call site of a required option would need a redundant null check for a case
+ * Discord's own validation makes impossible.
+ */
+export interface CommandOptions {
+  getString(name: string, required: true): string
+  getString(name: string, required?: boolean): string | null
+  getInteger(name: string, required: true): number
+  getInteger(name: string, required?: boolean): number | null
+  getBoolean(name: string, required: true): boolean
+  getBoolean(name: string, required?: boolean): boolean | null
+}
+
+export interface CommandContext {
+  readonly options: CommandOptions
+  /**
+   * The invoking user's display name. Only `/root` uses it, but it is here
+   * rather than passed separately because it is interaction data, and routing
+   * it around the context would put a second transport-shaped argument back
+   * into every signature.
+   */
+  readonly userDisplayName: string
+}
+
+/**
+ * Read options out of a raw Discord interaction payload.
+ *
+ * Discord sends options as a flat array of `{ name, type, value }`. This maps
+ * that to the same accessor shape discord.js exposes, so one command body
+ * serves both transports.
+ *
+ * `required` is accepted and ignored on purpose: discord.js throws when a
+ * required option is missing, but Discord itself will not send a command
+ * invocation missing a required option — its own validation runs first.
+ * Throwing here would turn a protocol impossibility into a runtime risk.
+ */
+export function optionsFromPayload(
+  raw: readonly { readonly name: string; readonly value?: unknown }[] | undefined
+): CommandOptions {
+  const byName = new Map((raw ?? []).map(option => [option.name, option.value]))
+
+  // Declared as functions rather than object-literal properties because only
+  // function declarations can carry overload signatures, and the overloads are
+  // what let `required: true` narrow away the null.
+  function getString(name: string, required: true): string
+  function getString(name: string, required?: boolean): string | null
+  function getString(name: string): string | null {
+    const value = byName.get(name)
+    return typeof value === 'string' ? value : null
+  }
+
+  function getInteger(name: string, required: true): number
+  function getInteger(name: string, required?: boolean): number | null
+  function getInteger(name: string): number | null {
+    const value = byName.get(name)
+    return typeof value === 'number' ? value : null
+  }
+
+  function getBoolean(name: string, required: true): boolean
+  function getBoolean(name: string, required?: boolean): boolean | null
+  function getBoolean(name: string): boolean | null {
+    const value = byName.get(name)
+    return typeof value === 'boolean' ? value : null
+  }
+
+  return { getString, getInteger, getBoolean }
+}

--- a/apps/discord-bot/src/commands/lib/index.ts
+++ b/apps/discord-bot/src/commands/lib/index.ts
@@ -2,11 +2,37 @@ import { deferReplyHonoringHidden } from '../../utils/ephemeral.js'
 import { replyWithError } from '../../utils/replyWithError.js'
 import type { ChatInputCommandInteraction, EmbedBuilder } from '../../utils/discord.js'
 import type { Command } from '../../types.js'
+import type { CommandContext } from './context.js'
+
+export type { CommandContext, CommandOptions } from './context.js'
+export { optionsFromPayload } from './context.js'
+
+/**
+ * Build the transport-agnostic context from a live gateway interaction.
+ *
+ * discord.js's `interaction.options` already has the accessor shape
+ * `CommandOptions` describes, so this is a narrowing rather than an adapter —
+ * which is the point: the interface was defined to fit what already exists, so
+ * neither transport pays a translation cost.
+ */
+export function contextFromInteraction(interaction: ChatInputCommandInteraction): CommandContext {
+  return {
+    options: interaction.options,
+    // A getter, not a value. Only `/root` reads the display name, and reading
+    // it eagerly here would touch `interaction.user` on every command — which
+    // changes behaviour for the nine that never did, and immediately broke the
+    // test fixtures that (reasonably) only mock what their command uses.
+    // Deferring keeps this refactor genuinely invisible.
+    get userDisplayName() {
+      return interaction.user.displayName
+    }
+  }
+}
 
 interface CreateGameCommandOptions {
   readonly data: Command['data']
-  readonly buildEmbed: (interaction: ChatInputCommandInteraction) => EmbedBuilder
-  readonly describeError?: (error: unknown, interaction: ChatInputCommandInteraction) => string
+  readonly buildEmbed: (context: CommandContext) => EmbedBuilder
+  readonly describeError?: (error: unknown, context: CommandContext) => string
   readonly autocomplete?: Command['autocomplete']
 }
 
@@ -31,13 +57,14 @@ export function createGameCommand(options: CreateGameCommandOptions): Command {
     data,
     async execute(interaction) {
       await deferReplyHonoringHidden(interaction)
+      const context = contextFromInteraction(interaction)
 
       try {
-        const embed = buildEmbed(interaction)
+        const embed = buildEmbed(context)
         await interaction.editReply({ embeds: [embed] })
       } catch (error) {
         const description = describeError
-          ? describeError(error, interaction)
+          ? describeError(error, context)
           : defaultErrorMessage(error)
         await replyWithError(interaction, 'Error', description)
       }

--- a/apps/discord-bot/src/commands/pbta.ts
+++ b/apps/discord-bot/src/commands/pbta.ts
@@ -2,14 +2,14 @@ import { EmbedBuilder, SlashCommandBuilder } from '../utils/discord.js'
 import { roll } from '@randsum/games/pbta'
 import { embedFooterDetails } from '../utils/constants.js'
 import { createGameCommand, formatSignedModifier, getInitialRolls } from './lib/index.js'
-import type { ChatInputCommandInteraction } from '../utils/discord.js'
+import type { CommandContext } from './lib/index.js'
 import type { Command } from '../types.js'
 
-function buildPbtaEmbed(interaction: ChatInputCommandInteraction): EmbedBuilder {
-  const stat = interaction.options.getInteger('stat', true)
-  const forward = interaction.options.getInteger('forward') ?? 0
-  const ongoing = interaction.options.getInteger('ongoing') ?? 0
-  const rollingWith = interaction.options.getString('rolling_with') as
+function buildPbtaEmbed(context: CommandContext): EmbedBuilder {
+  const stat = context.options.getInteger('stat', true)
+  const forward = context.options.getInteger('forward') ?? 0
+  const ongoing = context.options.getInteger('ongoing') ?? 0
+  const rollingWith = context.options.getString('rolling_with') as
     | 'Advantage'
     | 'Disadvantage'
     | null

--- a/apps/discord-bot/src/commands/roll.ts
+++ b/apps/discord-bot/src/commands/roll.ts
@@ -4,11 +4,11 @@ import { notation as createNotation } from '@randsum/roller/validate'
 import { suggestNotationFix } from '@randsum/roller'
 import { embedFooterDetails } from '../utils/constants.js'
 import { createGameCommand, defaultErrorMessage } from './lib/index.js'
-import type { ChatInputCommandInteraction } from '../utils/discord.js'
+import type { CommandContext } from './lib/index.js'
 import type { Command } from '../types.js'
 
-function buildRollEmbed(interaction: ChatInputCommandInteraction): EmbedBuilder {
-  const notationString = interaction.options.getString('notation', true)
+function buildRollEmbed(context: CommandContext): EmbedBuilder {
+  const notationString = context.options.getString('notation', true)
   const validNotation = createNotation(notationString)
   const result = roll(validNotation)
 
@@ -46,8 +46,8 @@ function buildRollEmbed(interaction: ChatInputCommandInteraction): EmbedBuilder 
   return embed
 }
 
-function describeRollError(error: unknown, interaction: ChatInputCommandInteraction): string {
-  const notationString = interaction.options.getString('notation', true)
+function describeRollError(error: unknown, context: CommandContext): string {
+  const notationString = context.options.getString('notation', true)
   const baseMessage = defaultErrorMessage(error)
   const suggestion = suggestNotationFix(notationString)
   return suggestion ? `${baseMessage}\n\nDid you mean \`${suggestion}\`?` : baseMessage

--- a/apps/discord-bot/src/commands/root.ts
+++ b/apps/discord-bot/src/commands/root.ts
@@ -2,12 +2,12 @@ import { EmbedBuilder, SlashCommandBuilder } from '../utils/discord.js'
 import { roll } from '@randsum/games/root-rpg'
 import { embedFooterDetails } from '../utils/constants.js'
 import { createGameCommand, formatSignedModifier, getInitialRolls } from './lib/index.js'
-import type { ChatInputCommandInteraction } from '../utils/discord.js'
+import type { CommandContext } from './lib/index.js'
 import type { Command } from '../types.js'
 
-function buildRootEmbed(interaction: ChatInputCommandInteraction): EmbedBuilder {
-  const modifier = interaction.options.getInteger('modifier') ?? 0
-  const displayName = interaction.user.displayName
+function buildRootEmbed(context: CommandContext): EmbedBuilder {
+  const modifier = context.options.getInteger('modifier') ?? 0
+  const displayName = context.userDisplayName
 
   const result = roll({ bonus: modifier })
   const initialRolls = getInitialRolls(result)


### PR DESCRIPTION
Groundwork for Phase 5 of the Cloudflare migration, and useful on its own. **No behaviour change** — the gateway bot works exactly as before, and all 132 tests pass unmodified.

## Why

Moving to Discord's HTTP-interactions model means there is no `Client` and no `Interaction` object — just raw JSON POSTed to a Worker. The question that decides whether that migration is days or weeks is how much command code actually depends on discord.js.

**The answer turned out to be: almost none of it.** Every game command already routes through a `createGameCommand({ data, buildEmbed })` factory, and `buildEmbed` touched exactly two things — three option getters, and in one command the caller's display name. Everything else about `ChatInputCommandInteraction` is transport.

So this names that slice as `CommandContext`:

- **Gateway** satisfies it from `interaction.options` — which already has the right shape, so this is a *narrowing*, not an adapter. The interface was defined to fit what exists, so neither transport pays a translation cost.
- **A Worker** will satisfy it via `optionsFromPayload`, reading the same values from Discord's flat `{name, value}` array.

## Two details worth keeping

**The accessors are overloaded**, not plain `=> T | null`, so `required: true` narrows away the null exactly as discord.js does. Without that, every required-option call site would need a redundant null check for a case Discord's own validation makes impossible.

**`userDisplayName` is a getter, not a value.** Reading it eagerly touched `interaction.user` on all ten commands when only `/root` ever did — a real behaviour change that immediately broke **44 tests** whose fixtures reasonably only mock what their command uses. Deferring the read keeps the refactor genuinely invisible. That failure was a useful signal, not an inconvenience: it caught the change before review did.

## Tests

`optionsFromPayload` gets its own suite, because it's the piece that must match discord.js's semantics *without being discord.js*. A divergence there surfaces as a command reading `null` for an option the user did supply — which looks like a game-logic bug and gets hunted for in entirely the wrong file.

The cases pinned are the ones that actually bite:
- a `false` boolean must not be mistaken for absent
- a `0` integer must not either (`/blades` accepts 0 dice as meaningful)
- a wrong-typed value must not silently coerce

## Test plan

- `bun run --filter @randsum/discord-bot check` → exit 0
- 132 tests pass (6 new), **zero existing tests modified**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Qeum9i6jZtAHoziAZFHSsH