### PR TITLE
feat(discord-bot): make the Worker bundleable — split the discord barrel

### DIFF
--- a/apps/discord-bot/package.json
+++ b/apps/discord-bot/package.json
@@ -16,8 +16,10 @@
   },
   "type": "module",
   "dependencies": {
+    "@discordjs/builders": "1.14.1",
     "@randsum/games": "workspace:~",
     "@randsum/roller": "workspace:~",
+    "discord-api-types": "0.38.49",
     "discord.js": "^14.26.4"
   },
   "keywords": [

--- a/apps/discord-bot/src/commands/blades.ts
+++ b/apps/discord-bot/src/commands/blades.ts
@@ -1,4 +1,4 @@
-import { EmbedBuilder, SlashCommandBuilder } from '../utils/discord.js'
+import { EmbedBuilder, SlashCommandBuilder } from '../utils/builders.js'
 import { roll } from '@randsum/games/blades'
 import { embedFooterDetails } from '../utils/constants.js'
 import { createGameCommand, getInitialRolls } from './lib/index.js'

--- a/apps/discord-bot/src/commands/dh.ts
+++ b/apps/discord-bot/src/commands/dh.ts
@@ -1,4 +1,4 @@
-import { EmbedBuilder, SlashCommandBuilder } from '../utils/discord.js'
+import { EmbedBuilder, SlashCommandBuilder } from '../utils/builders.js'
 import { roll } from '@randsum/games/daggerheart'
 import { embedFooterDetails } from '../utils/constants.js'
 import { createGameCommand, formatSignedModifier } from './lib/index.js'

--- a/apps/discord-bot/src/commands/fate.ts
+++ b/apps/discord-bot/src/commands/fate.ts
@@ -1,4 +1,4 @@
-import { EmbedBuilder, SlashCommandBuilder } from '../utils/discord.js'
+import { EmbedBuilder, SlashCommandBuilder } from '../utils/builders.js'
 import { roll } from '@randsum/games/fate'
 import type { FateRollResult } from '@randsum/games/fate'
 import { embedFooterDetails } from '../utils/constants.js'

--- a/apps/discord-bot/src/commands/fifth.ts
+++ b/apps/discord-bot/src/commands/fifth.ts
@@ -1,4 +1,4 @@
-import { EmbedBuilder, SlashCommandBuilder } from '../utils/discord.js'
+import { EmbedBuilder, SlashCommandBuilder } from '../utils/builders.js'
 import { roll } from '@randsum/games/fifth'
 import { embedFooterDetails } from '../utils/constants.js'
 import { createGameCommand, formatSignedModifier, getInitialRolls } from './lib/index.js'

--- a/apps/discord-bot/src/commands/help.ts
+++ b/apps/discord-bot/src/commands/help.ts
@@ -1,4 +1,4 @@
-import { EmbedBuilder, SlashCommandBuilder } from '../utils/discord.js'
+import { EmbedBuilder, SlashCommandBuilder } from '../utils/builders.js'
 import type { Client, Collection } from '../utils/discord.js'
 import { embedFooterDetails } from '../utils/constants.js'
 import { deferReplyHonoringHidden } from '../utils/ephemeral.js'
@@ -28,7 +28,7 @@ export const helpCommand: Command = {
       }))
 
     const embed = new EmbedBuilder()
-      .setColor('#FFD700')
+      .setColor(0xffd700)
       .setTitle('RANDSUM Commands')
       .setDescription('Here are all the available commands:')
       .addFields(fields)

--- a/apps/discord-bot/src/commands/lib/index.ts
+++ b/apps/discord-bot/src/commands/lib/index.ts
@@ -1,6 +1,7 @@
 import { deferReplyHonoringHidden } from '../../utils/ephemeral.js'
 import { replyWithError } from '../../utils/replyWithError.js'
-import type { ChatInputCommandInteraction, EmbedBuilder } from '../../utils/discord.js'
+import type { EmbedBuilder } from '../../utils/builders.js'
+import type { ChatInputCommandInteraction } from '../../utils/discord.js'
 import type { Command } from '../../types.js'
 import type { CommandContext } from './context.js'
 

--- a/apps/discord-bot/src/commands/notation.ts
+++ b/apps/discord-bot/src/commands/notation.ts
@@ -4,7 +4,7 @@ import {
   EmbedBuilder,
   SlashCommandBuilder,
   StringSelectMenuBuilder
-} from '../utils/discord.js'
+} from '../utils/builders.js'
 import type { StringSelectMenuInteraction } from '../utils/discord.js'
 import { NOTATION_DOCS } from '@randsum/roller/docs'
 import type { NotationDoc } from '@randsum/roller/docs'
@@ -40,7 +40,7 @@ function buildCategoryEmbed(category: string, entries: NotationDoc[]): EmbedBuil
   }))
 
   return new EmbedBuilder()
-    .setColor('#FFD700')
+    .setColor(0xffd700)
     .setTitle('notation.randsum.dev')
     .setURL('https://notation.randsum.dev')
     .setDescription(`**${category}** modifiers`)

--- a/apps/discord-bot/src/commands/pbta.ts
+++ b/apps/discord-bot/src/commands/pbta.ts
@@ -1,4 +1,4 @@
-import { EmbedBuilder, SlashCommandBuilder } from '../utils/discord.js'
+import { EmbedBuilder, SlashCommandBuilder } from '../utils/builders.js'
 import { roll } from '@randsum/games/pbta'
 import { embedFooterDetails } from '../utils/constants.js'
 import { createGameCommand, formatSignedModifier, getInitialRolls } from './lib/index.js'

--- a/apps/discord-bot/src/commands/roll.ts
+++ b/apps/discord-bot/src/commands/roll.ts
@@ -1,4 +1,4 @@
-import { EmbedBuilder, SlashCommandBuilder } from '../utils/discord.js'
+import { EmbedBuilder, SlashCommandBuilder } from '../utils/builders.js'
 import { roll } from '@randsum/roller/roll'
 import { notation as createNotation } from '@randsum/roller/validate'
 import { suggestNotationFix } from '@randsum/roller'
@@ -13,7 +13,7 @@ function buildRollEmbed(context: CommandContext): EmbedBuilder {
   const result = roll(validNotation)
 
   const embed = new EmbedBuilder()
-    .setColor('#FFD700')
+    .setColor(0xffd700)
     .setTitle(`You rolled a ${result.total}`)
     .setDescription(`Rolling: ${notationString}`)
     .setFooter(embedFooterDetails)

--- a/apps/discord-bot/src/commands/root.ts
+++ b/apps/discord-bot/src/commands/root.ts
@@ -1,4 +1,4 @@
-import { EmbedBuilder, SlashCommandBuilder } from '../utils/discord.js'
+import { EmbedBuilder, SlashCommandBuilder } from '../utils/builders.js'
 import { roll } from '@randsum/games/root-rpg'
 import { embedFooterDetails } from '../utils/constants.js'
 import { createGameCommand, formatSignedModifier, getInitialRolls } from './lib/index.js'

--- a/apps/discord-bot/src/commands/salvageunion.ts
+++ b/apps/discord-bot/src/commands/salvageunion.ts
@@ -1,4 +1,4 @@
-import { EmbedBuilder, SlashCommandBuilder } from '../utils/discord.js'
+import { EmbedBuilder, SlashCommandBuilder } from '../utils/builders.js'
 import { deferReplyHonoringHidden } from '../utils/ephemeral.js'
 import { embedFooterDetails } from '../utils/constants.js'
 import type { Command } from '../types.js'

--- a/apps/discord-bot/src/events/guildCreate.ts
+++ b/apps/discord-bot/src/events/guildCreate.ts
@@ -7,7 +7,7 @@ export async function guildCreateHandler(guild: Guild): Promise<void> {
   if (guild.systemChannel === null) return
 
   const embed = new EmbedBuilder()
-    .setColor('#A855F7')
+    .setColor(0xa855f7)
     .setTitle('Welcome to RANDSUM!')
     .setDescription(
       'RANDSUM — Roll dice for your TTRPG sessions\n\nKey commands:\n`/roll` — Roll any dice notation\n`/notation` — Browse the notation reference\n`/blades`, `/dh`, `/fate`, `/fifth`, `/pbta`, `/root` — Game-specific rolls\n`/help` — List all commands\n\nLearn the full dice notation spec at https://notation.randsum.dev'

--- a/apps/discord-bot/src/types.ts
+++ b/apps/discord-bot/src/types.ts
@@ -1,10 +1,16 @@
 import type {
   AutocompleteInteraction,
   ChatInputCommandInteraction,
-  EmbedBuilder,
   SlashCommandBuilder,
   SlashCommandOptionsOnlyBuilder
 } from 'discord.js'
+// Deliberately the portable builder, not discord.js's. discord.js does not
+// re-export @discordjs/builders verbatim — it *subclasses* EmbedBuilder, adding
+// `.length` and accepting hex-string colours. The two are therefore distinct
+// types, and a command that returns one cannot satisfy a signature demanding
+// the other. Since command renderers must run on workerd, the portable one wins
+// and the gateway path accepts it happily (it is a JSONEncodable<APIEmbed>).
+import type { EmbedBuilder } from './utils/builders.js'
 import type { CommandContext } from './commands/lib/context.js'
 
 export interface Command {

--- a/apps/discord-bot/src/utils/builders.ts
+++ b/apps/discord-bot/src/utils/builders.ts
@@ -1,0 +1,33 @@
+/**
+ * Portable Discord primitives — safe on Node and on workerd.
+ *
+ * The counterpart to `discord.ts`, which is the *gateway* barrel: `Client`,
+ * `Collection`, `Events`, `GatewayIntentBits`. Those exist only to hold and
+ * service a WebSocket, and none of them can run on Workers.
+ *
+ * Everything here is different in kind. Builders and enums are pure data
+ * construction with no runtime dependency on a connection — and crucially they
+ * do not actually live in discord.js at all. discord.js re-exports them from
+ * `@discordjs/builders` and `discord-api-types`, which are ordinary portable
+ * packages. Importing from the source rather than through discord.js is what
+ * lets a command file compile for both targets with no aliasing, no bundler
+ * tricks, and no second implementation.
+ *
+ * The version is pinned to the one discord.js itself depends on, so the classes
+ * here are the same classes it would hand back. A drift there would produce
+ * two `EmbedBuilder` identities in one process, which fails in a genuinely
+ * confusing way.
+ *
+ * The rule this encodes: **command files import from here, never from
+ * `discord.ts`.** Anything that needs the gateway barrel is transport, and
+ * belongs in the gateway entry point.
+ */
+export {
+  ActionRowBuilder,
+  ButtonBuilder,
+  EmbedBuilder,
+  SlashCommandBuilder,
+  StringSelectMenuBuilder
+} from '@discordjs/builders'
+
+export { ComponentType, MessageFlags } from 'discord-api-types/v10'

--- a/apps/discord-bot/src/utils/ephemeral.ts
+++ b/apps/discord-bot/src/utils/ephemeral.ts
@@ -1,4 +1,4 @@
-import { MessageFlags } from './discord.js'
+import { MessageFlags } from './builders.js'
 import type { ChatInputCommandInteraction } from './discord.js'
 
 /**

--- a/apps/discord-bot/src/utils/errorTracker.ts
+++ b/apps/discord-bot/src/utils/errorTracker.ts
@@ -24,7 +24,6 @@
  *    awaits in-flight sends so those paths can shut down without losing the
  *    one event explaining why.
  */
-import { randomUUID } from 'node:crypto'
 import { logger } from './logger.js'
 
 export interface ErrorContext {
@@ -205,7 +204,11 @@ async function postEnvelope(
   context: ErrorContext
 ): Promise<void> {
   try {
-    const eventId = randomUUID().replaceAll('-', '')
+    // The WebCrypto global, not `node:crypto`. Identical output, but it exists
+    // on workerd as well as Node — importing the Node module made this whole
+    // module unloadable in a Worker ("No such module node:crypto") unless the
+    // nodejs_compat flag was enabled, which is a large hammer for one UUID.
+    const eventId = crypto.randomUUID().replaceAll('-', '')
     const described = describeError(error)
     const event = {
       event_id: eventId,

--- a/apps/discord-bot/src/utils/replyWithError.ts
+++ b/apps/discord-bot/src/utils/replyWithError.ts
@@ -1,5 +1,5 @@
 import type { ChatInputCommandInteraction } from './discord.js'
-import { EmbedBuilder } from './discord.js'
+import { EmbedBuilder } from './builders.js'
 import { embedFooterDetails } from './constants.js'
 
 export async function replyWithError(
@@ -8,7 +8,7 @@ export async function replyWithError(
   description: string
 ): Promise<void> {
   const embed = new EmbedBuilder()
-    .setColor('#FF0000')
+    .setColor(0xff0000)
     .setTitle(title)
     .setDescription(description)
     .setFooter(embedFooterDetails)

--- a/apps/discord-bot/src/worker/dispatch.ts
+++ b/apps/discord-bot/src/worker/dispatch.ts
@@ -12,7 +12,7 @@
  * alive, no second failure mode) and visibly faster — the user never sees a
  * "thinking…" state for work that was already done.
  */
-import { MessageFlags } from '../utils/discord.js'
+import { MessageFlags } from '../utils/builders.js'
 import { optionsFromPayload } from '../commands/lib/context.js'
 import { defaultErrorMessage } from '../commands/lib/index.js'
 import type { Command } from '../types.js'

--- a/apps/discord-bot/wrangler.jsonc
+++ b/apps/discord-bot/wrangler.jsonc
@@ -1,0 +1,26 @@
+{
+  // Cloudflare Worker for the Discord bot — HTTP interactions.
+  //
+  // NOT WIRED UP. Deploying this changes nothing on its own: Discord only sends
+  // interactions here once an Interactions Endpoint URL is set in the
+  // application settings, and doing that STOPS gateway delivery entirely. The
+  // two transports are mutually exclusive, so the switch is a deliberate,
+  // one-way-feeling cutover — see apps/discord-bot/CLAUDE.md before flipping it.
+  //
+  // Wrangler bundles the TypeScript entry directly; there is no separate build
+  // step, unlike the gateway bot which bunup-bundles for Node.
+  "$schema": "node_modules/wrangler/config-schema.json",
+  "name": "randsum-discord-bot",
+  "main": "./src/worker/index.ts",
+  // Matches the sites: newer than the locally installed wrangler's workerd
+  // supports would make `wrangler dev` refuse to start, and local testing is
+  // the only way to exercise this before Discord is pointed at it.
+  "compatibility_date": "2026-07-13",
+  "observability": {
+    "enabled": true
+  }
+  // DISCORD_PUBLIC_KEY is intentionally absent. It is not a secret — it is the
+  // application's public key — but it is environment-specific, so it is set via
+  // `wrangler secret put` / the dashboard rather than committed. With it unset
+  // the Worker rejects every request, which is the correct failure direction.
+}

--- a/bun.lock
+++ b/bun.lock
@@ -33,8 +33,10 @@
       "name": "@randsum/discord-bot",
       "version": "1.1.2",
       "dependencies": {
+        "@discordjs/builders": "1.14.1",
         "@randsum/games": "workspace:~",
         "@randsum/roller": "workspace:~",
+        "discord-api-types": "0.38.49",
         "discord.js": "^14.26.4",
       },
     },


### PR DESCRIPTION
**The Worker now builds and boots on workerd.** 678 KiB raw, **115 KiB gzipped** — comfortably inside the 3 MB free-tier limit — with no gateway client in the bundle. Verified with `wrangler deploy --dry-run` and `wrangler dev`.

## The problem

`utils/discord.ts` was doing two unrelated jobs: handing out **builders and enums** (pure data construction) and handing out **`Client`/`Events`/`GatewayIntentBits`** (which exist only to hold a WebSocket). Command files needed the first and got the second — so every command transitively imported discord.js, and no Worker build could ever succeed.

`utils/builders.ts` is now the portable half. The rule it encodes: **command files import from there, never from `discord.ts`.** Anything reaching for the gateway barrel is transport and belongs in the gateway entry point.

## Three things the plan didn't anticipate

**1. discord.js doesn't re-export `@discordjs/builders` — it *subclasses* it.** Its `EmbedBuilder` adds `.length` and accepts hex-string colours, so the two are genuinely distinct types and a command returning one can't satisfy a signature demanding the other. "Just import from the underlying package" is not the drop-in it sounds like.

The portable builder wins, because command renderers have to run on workerd — and the gateway path accepts it happily since it's a `JSONEncodable<APIEmbed>`. Five hex-string `setColor` calls became numeric literals, which **both** builders accept.

**2. `errorTracker` imported `randomUUID` from `node:crypto`**, which made the module unloadable in a Worker outright (`No such module "node:crypto"`). Switched to the WebCrypto global — identical output, exists on both runtimes, and avoids dragging in `nodejs_compat` and a pile of Node polyfills for one UUID.

**3. Type-only imports of gateway types are fine and stay.** Three files still `import type` from `discord.ts`; those are erased at build time and never reach the bundle. Confirmed by inspecting the output — no `WebSocketManager`, no discord.js client. The only gateway-shaped string remaining is `GatewayIntentBits`, a plain enum from `discord-api-types`.

## `wrangler.jsonc`, deliberately not wired to any deploy

Deploying it changes nothing on its own: Discord only routes here once an Interactions Endpoint URL is set, and setting that **stops gateway delivery entirely**. `DISCORD_PUBLIC_KEY` is left unset, so the Worker currently rejects every request — the correct direction to fail in.

## Verified locally

| Request | Result |
| --- | --- |
| Unsigned POST | **401** |
| Bad-signature POST | **401** |
| GET | **405** |

## Still not at parity — do not point Discord at this

`/help`, `/notation` and `/salvageunion` have no Worker renderer, and `/notation`'s collector-based pagination still needs redesigning around `custom_id`.

## Test plan

- `bun run --filter @randsum/discord-bot check` → exit 0
- `bun run knip` → clean
- 148 tests pass, **zero existing tests modified** — the gateway bot is unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Qeum9i6jZtAHoziAZFHSsH