### PR TITLE
feat(discord-bot): port /help and /salvageunion to the Worker

### DIFF
--- a/apps/discord-bot/__tests__/commands/help.test.ts
+++ b/apps/discord-bot/__tests__/commands/help.test.ts
@@ -80,7 +80,17 @@ describe('helpCommand', () => {
     expect(embedJson.footer).toBeDefined()
   })
 
-  test('execute: lists commands from the client collection, excluding help itself', async () => {
+  test('execute: lists commands from the barrel, excluding help itself', async () => {
+    // Source of truth changed deliberately. `/help` used to read
+    // `client.commands`, which only exists on the gateway — a Worker has no
+    // client, so the same command could not have rendered there. It now reads
+    // the command barrel, which `apps/discord-bot/CLAUDE.md` already calls the
+    // single source of truth for what commands exist.
+    //
+    // Importing the barrel is what publishes the registry, so the import below
+    // is load-bearing rather than incidental.
+    await import('../../src/commands/index.js')
+
     const interaction = makeInteraction()
     await helpCommand.execute(interaction as never)
     const call = interaction.editReply.mock.calls[0]?.[0] as {

--- a/apps/discord-bot/__tests__/worker/dispatch.test.ts
+++ b/apps/discord-bot/__tests__/worker/dispatch.test.ts
@@ -92,9 +92,26 @@ describe('dispatchInteraction', () => {
     expect(response.data?.embeds?.[0]?.title).toBe('Error')
   })
 
+  test('renders /help from the barrel, not from a gateway client', () => {
+    const response = invoke('help')
+    expect(response.type).toBe(InteractionResponseType.ChannelMessageWithSource)
+
+    // The real proof it reads the registry: a Worker has no client, so an
+    // empty field list here would mean /help silently renders nothing.
+    const names = (response.data?.embeds?.[0]?.fields ?? []).map(field => field.name)
+    expect(names).toContain('/roll')
+    expect(names).not.toContain('/help')
+  })
+
+  test('renders /salvageunion', () => {
+    const response = invoke('salvageunion')
+    expect(response.type).toBe(InteractionResponseType.ChannelMessageWithSource)
+    expect(response.data?.embeds?.[0]?.title).toBe('Salvage Union has moved')
+  })
+
   test('reports commands that have no Worker renderer yet', () => {
-    // /help, /notation and /salvageunion do not go through the factory, so they
-    // have no buildEmbed. They must say so rather than silently do nothing.
+    // /notation is the last holdout — its pagination uses a gateway-only
+    // component collector. It must say so rather than silently do nothing.
     const response = invoke('notation')
     expect(response.data?.embeds?.[0]?.title).toBe('Error')
   })

--- a/apps/discord-bot/src/commands/help.ts
+++ b/apps/discord-bot/src/commands/help.ts
@@ -1,10 +1,16 @@
 import { EmbedBuilder, SlashCommandBuilder } from '../utils/builders.js'
-import type { Client, Collection } from '../utils/discord.js'
 import { embedFooterDetails } from '../utils/constants.js'
-import { deferReplyHonoringHidden } from '../utils/ephemeral.js'
+import { createGameCommand } from './lib/index.js'
+import { commandRegistry } from './lib/registry.js'
 import type { Command } from '../types.js'
 
-export const helpCommand: Command = {
+/**
+ * `/help` reads the registry rather than `client.commands`, which is what makes
+ * it work on both transports — a Worker has no client to read a registry off.
+ * The barrel publishes the list; see `lib/registry.ts` for why it is pushed
+ * rather than imported.
+ */
+export const helpCommand: Command = createGameCommand({
   data: new SlashCommandBuilder()
     .setName('help')
     .setDescription('List all available RANDSUM commands')
@@ -14,26 +20,20 @@ export const helpCommand: Command = {
         .setDescription('Make the result visible only to you')
         .setRequired(false)
     ),
-
-  async execute(interaction) {
-    await deferReplyHonoringHidden(interaction)
-
-    const client = interaction.client as Client & { commands: Collection<string, Command> }
-    const fields = [...client.commands.values()]
-      .filter(cmd => cmd.data.name !== 'help')
-      .map(cmd => ({
-        name: `/${cmd.data.name}`,
-        value: cmd.data.description,
+  buildEmbed: () => {
+    const fields = commandRegistry()
+      .filter(command => command.data.name !== 'help')
+      .map(command => ({
+        name: `/${command.data.name}`,
+        value: command.data.description,
         inline: false
       }))
 
-    const embed = new EmbedBuilder()
+    return new EmbedBuilder()
       .setColor(0xffd700)
       .setTitle('RANDSUM Commands')
       .setDescription('Here are all the available commands:')
       .addFields(fields)
       .setFooter(embedFooterDetails)
-
-    await interaction.editReply({ embeds: [embed] })
   }
-}
+})

--- a/apps/discord-bot/src/commands/index.ts
+++ b/apps/discord-bot/src/commands/index.ts
@@ -1,4 +1,5 @@
 import type { Command } from '../types.js'
+import { setCommandRegistry } from './lib/registry.js'
 import { bladesCommand } from './blades.js'
 import { dhCommand } from './dh.js'
 import { fateCommand } from './fate.js'
@@ -10,7 +11,7 @@ import { rollCommand } from './roll.js'
 import { rootCommand } from './root.js'
 import { salvageUnionCommand } from './salvageunion.js'
 
-export const commands: readonly Command[] = [
+const commandList: readonly Command[] = [
   bladesCommand,
   dhCommand,
   fateCommand,
@@ -22,3 +23,10 @@ export const commands: readonly Command[] = [
   rootCommand,
   salvageUnionCommand
 ]
+
+// Published for `/help`, which needs the list of its siblings. Pushed rather
+// than imported so `/help` never has to import this barrel, which would be a
+// cycle — see lib/registry.ts.
+setCommandRegistry(commandList)
+
+export const commands: readonly Command[] = commandList

--- a/apps/discord-bot/src/commands/lib/registry.ts
+++ b/apps/discord-bot/src/commands/lib/registry.ts
@@ -1,0 +1,27 @@
+/**
+ * The command list, published by the barrel and read by `/help`.
+ *
+ * `/help` is the one command whose content depends on the *other* commands, so
+ * it needs the registry. It used to read `client.commands`, which works only on
+ * the gateway — a Worker has no client.
+ *
+ * Importing the barrel directly would be circular, since the barrel contains
+ * `/help`. Inverting it removes the cycle entirely: the barrel *pushes* the list
+ * here once, and `/help` pulls it. Nothing imports the barrel except the
+ * transports.
+ *
+ * Deliberately synchronous and eager. A lazy async variant works too, but it
+ * races: the first `/help` before the import settles renders an empty list, and
+ * that is precisely the kind of bug that only appears under a cold start.
+ */
+import type { Command } from '../../types.js'
+
+const state: { commands: readonly Command[] } = { commands: [] }
+
+export function setCommandRegistry(commands: readonly Command[]): void {
+  state.commands = commands
+}
+
+export function commandRegistry(): readonly Command[] {
+  return state.commands
+}

--- a/apps/discord-bot/src/commands/salvageunion.ts
+++ b/apps/discord-bot/src/commands/salvageunion.ts
@@ -1,6 +1,6 @@
 import { EmbedBuilder, SlashCommandBuilder } from '../utils/builders.js'
-import { deferReplyHonoringHidden } from '../utils/ephemeral.js'
 import { embedFooterDetails } from '../utils/constants.js'
+import { createGameCommand } from './lib/index.js'
 import type { Command } from '../types.js'
 
 /**
@@ -16,7 +16,7 @@ const SUREF_CLIENT_ID = '1442878052823470172'
 const SUREF_INVITE_URL = `https://discord.com/oauth2/authorize?client_id=${SUREF_CLIENT_ID}&scope=bot%20applications.commands&permissions=0`
 const SUREF_INFO_URL = 'https://salvageunion.io/discord'
 
-export const salvageUnionCommand: Command = {
+export const salvageUnionCommand: Command = createGameCommand({
   data: new SlashCommandBuilder()
     .setName('salvageunion')
     .setDescription('Salvage Union rolls have moved to the SURef bot from salvageunion.io')
@@ -26,11 +26,10 @@ export const salvageUnionCommand: Command = {
         .setDescription('Make the result visible only to you')
         .setRequired(false)
     ),
-
-  async execute(interaction) {
-    await deferReplyHonoringHidden(interaction)
-
-    const embed = new EmbedBuilder()
+  // Static content, so it takes no context at all — which is exactly why it
+  // moves to the factory for free and works on either transport unchanged.
+  buildEmbed: () =>
+    new EmbedBuilder()
       .setColor(0xb7410e)
       .setTitle('Salvage Union has moved')
       .setDescription(
@@ -41,7 +40,4 @@ export const salvageUnionCommand: Command = {
         { name: 'Learn more', value: `[salvageunion.io/discord](${SUREF_INFO_URL})` }
       )
       .setFooter(embedFooterDetails)
-
-    await interaction.editReply({ embeds: [embed] })
-  }
-}
+})


### PR DESCRIPTION
**Nine of ten commands now render on the Worker.** Only `/notation` remains, and it's the one that genuinely needs *redesigning* rather than porting — its pagination uses a gateway-only component collector.

## `/salvageunion` was free

Static content, no context at all, so it moves to the command factory unchanged and works on either transport.

## `/help` needed one real decision

It read `client.commands` — which exists **only on the gateway**. A Worker has no client, so the command couldn't have rendered there at all.

It now reads the command barrel, which `apps/discord-bot/CLAUDE.md` already describes as *"the single source of truth for all commands."* That's a deliberate behaviour change, and the existing test was **updated to say so rather than deleted**.

## Getting the list there without a cycle

`/help` is *in* the barrel, so importing the barrel from `/help` is circular.

An async lazy import breaks the cycle but **races**: the first `/help` before the import settles renders an empty list — exactly the bug that only ever shows up on a cold start. I wrote that version first and backed it out.

So the barrel **pushes** the list into `lib/registry.ts` and `/help` pulls it. Nothing imports the barrel except the transports. No cycle, no race, no async.

## Test note

The dispatcher tests assert `/help` renders a **populated field list**, not merely that it returned a response. An empty list is precisely how this fails silently on a Worker, and asserting only "it responded" would have passed while shipping a blank help message.

## Test plan

- `bun run --filter @randsum/discord-bot check` → exit 0
- `bun run knip` → clean
- 148 tests pass; the one existing `/help` test updated to reflect the intended change in source of truth

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Qeum9i6jZtAHoziAZFHSsH