### PR TITLE
chore(mcp,docs): point tooling at Cloudflare now that both sites have moved

### DIFF
--- a/.mcp.json
+++ b/.mcp.json
@@ -1,18 +1,22 @@
 {
   "mcpServers": {
-    "render": {
+    "cloudflare-bindings": {
       "type": "http",
-      "url": "https://mcp.render.com/mcp",
-      "headersHelper": "$CLAUDE_PROJECT_DIR/scripts/mcp-1password-headers.sh"
+      "url": "https://bindings.mcp.cloudflare.com/mcp"
+    },
+    "cloudflare-observability": {
+      "type": "http",
+      "url": "https://observability.mcp.cloudflare.com/mcp"
     },
     "github": {
       "type": "http",
       "url": "https://api.githubcopilot.com/mcp/",
       "headersHelper": "$CLAUDE_PROJECT_DIR/scripts/mcp-1password-headers.sh"
     },
-    "netlify": {
+    "render": {
       "type": "http",
-      "url": "https://netlify-mcp.netlify.app/mcp"
+      "url": "https://mcp.render.com/mcp",
+      "headersHelper": "$CLAUDE_PROJECT_DIR/scripts/mcp-1password-headers.sh"
     }
   }
 }

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -205,11 +205,22 @@ accept unread.
 `.mcp.json` (project-scoped, committed) declares the official MCP servers for
 this repo's deploy/host stack. Each maps to a real workspace target:
 
-| Server    | Transport | Backs                              | Auth                            |
-| --------- | --------- | ---------------------------------- | ------------------------------- |
-| `render`  | http      | `apps/discord-bot` (Render worker) | 1Password PAT (`headersHelper`) |
-| `github`  | http      | repo host (issues, PRs, releases)  | 1Password PAT (`headersHelper`) |
-| `netlify` | http      | `apps/site` / `apps/rdn` (Netlify) | OAuth — run `/mcp`              |
+| Server                     | Transport | Backs                                     | Auth                            |
+| -------------------------- | --------- | ----------------------------------------- | ------------------------------- |
+| `cloudflare-bindings`      | http      | Workers, KV, D1 for both sites            | OAuth — run `/mcp`              |
+| `cloudflare-observability` | http      | Workers logs and analytics                | OAuth — run `/mcp`              |
+| `github`                   | http      | repo host (issues, PRs, releases)         | 1Password PAT (`headersHelper`) |
+| `render`                   | http      | `apps/discord-bot` — **until the bot moves** | 1Password PAT (`headersHelper`) |
+
+**`netlify` was removed**: both sites now serve from Cloudflare, so there is
+nothing left for it to manage. `render` stays only because the Discord bot still
+runs there; it goes when the bot moves to its Worker.
+
+Cloudflare's own MCP servers authenticate by OAuth rather than a bearer token,
+so they need no `headersHelper` and no vault item — run `/mcp` once to
+authorize. A third server, `docs.mcp.cloudflare.com`, is deliberately **not**
+declared: the vendored skills in `.claude/skills/` already cover platform
+guidance, and a tool surface every session pays for should earn its place.
 
 Secrets are **never** committed. The `github` and `render` (http) servers
 resolve their fine-grained PATs at connect time via `scripts/mcp-1password-headers.sh`,

--- a/apps/DEPLOY.md
+++ b/apps/DEPLOY.md
@@ -8,16 +8,26 @@ to file incident RCAs.
 
 ## Surface map
 
-| Surface            | App                                             | Host            | Trigger                  | URL                   |
-| ------------------ | ----------------------------------------------- | --------------- | ------------------------ | --------------------- |
-| Docs site          | `apps/site`                                     | Netlify         | push to `main`           | randsum.dev           |
-| Notation spec site | `apps/rdn`                                      | Netlify         | push to `main`           | notation.randsum.dev  |
-| Discord bot        | `apps/discord-bot`                              | Render (worker) | manual / Render redeploy | n/a (Discord gateway) |
-| npm packages       | `packages/roller`, `packages/games`, `apps/cli` | npm registry    | changesets on merge      | npmjs.com/org/randsum |
+| Surface            | App                                             | Host                | Trigger                  | URL                   |
+| ------------------ | ----------------------------------------------- | ------------------- | ------------------------ | --------------------- |
+| Docs site          | `apps/site`                                     | **Cloudflare**      | push to `main`           | randsum.dev           |
+| Notation spec site | `apps/rdn`                                      | **Cloudflare**      | push to `main`           | notation.randsum.dev  |
+| Discord bot        | `apps/discord-bot`                              | Render (worker)     | manual / Render redeploy | n/a (Discord gateway) |
+| npm packages       | `packages/roller`, `packages/games`, `apps/cli` | npm registry        | changesets on merge      | npmjs.com/org/randsum |
 
-> Config sources: `apps/site/netlify.toml`, `apps/rdn/netlify.toml`,
-> `render.yaml` (repo root). Workflow files live in `.github/workflows/` (owned separately —
-> see those files for the exact trigger steps).
+**Both sites migrated to Cloudflare on 2026-08-18.** DNS for `randsum.dev` is on
+Cloudflare (nameservers `davina`/`rajeev`.ns.cloudflare.com, registrar still
+Hover), and both sites serve from Workers with custom domains. `/api/roll` runs
+as a Worker route on the apex.
+
+> The Netlify projects and `netlify.toml` files are **kept, not deleted**, until
+> the migration has proven itself. They no longer serve traffic. Deleting them
+> is the last step, not part of the cutover — while they exist, reverting is
+> restoring two A records per hostname.
+
+> Config sources: `apps/site/wrangler.jsonc`, `apps/rdn/wrangler.jsonc`,
+> `render.yaml` (repo root), plus the still-present `netlify.toml` files.
+> Deployment runs from `.github/workflows/deploy-cloudflare.yml`.
 >
 > The `randsum.io` playground is a **legacy app deployed outside this monorepo** — it is not
 > built or deployed by any config here and is out of scope for this runbook.


### PR DESCRIPTION
**Both sites migrated to Cloudflare today.** `randsum.dev` and `notation.randsum.dev` serve from Workers with custom domains, `/api/roll` runs as a Worker route on the apex, and DNS is on Cloudflare nameservers with the registrar still at Hover.

## `.mcp.json`

**Added** `cloudflare-bindings` and `cloudflare-observability`. **Removed** `netlify` — both sites left it, so it has nothing left to manage.

Cloudflare's servers authenticate by **OAuth rather than a bearer token**, so they need no `headersHelper` and no vault item. Run `/mcp` once to authorize.

A third server, `docs.mcp.cloudflare.com`, is deliberately **not** declared even though it needs no auth at all. The skills vendored in `.claude/skills/` already cover platform guidance, and a tool surface every session pays for should earn its place — the same argument that trimmed those skills from thirteen to three in #1225.

`render` stays, narrowly: **the Discord bot still runs there.** It goes when the bot moves to its Worker, and the table says so rather than leaving someone to guess whether it was an oversight.

## `apps/DEPLOY.md`

Surface map updated — it claimed Netlify served both sites, which stopped being true today.

**The Netlify projects and `netlify.toml` files are kept on purpose.** They no longer serve traffic, but while they exist a revert is restoring two A records per hostname. Deleting them is the *last* step of the migration, not part of it.

## Verified live

| | |
| --- | --- |
| `randsum.dev` | 200, `server: cloudflare` |
| `POST /api/roll` | returns a correct roll |
| `/games/blades/` | 200 |
| `/schemas/v1/randsum.json` | 200, `application/json; charset=utf-8` |
| `/packages/fifth/` | 301 → `/games/fifth/` |
| `www.randsum.dev` | 200 |
| `notation.randsum.dev` | 200, `server: cloudflare` |
| 404 handling | 404 on both |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Qeum9i6jZtAHoziAZFHSsH
