### PR TITLE
feat(discord-bot): cut the bot over to the Cloudflare Worker

### DIFF
--- a/.github/workflows/deploy-cloudflare.yml
+++ b/.github/workflows/deploy-cloudflare.yml
@@ -1,21 +1,26 @@
-# Deploy static sites to Cloudflare Workers on merge to main.
+# Deploy every Cloudflare surface on merge to main.
 #
-# Netlify deploys itself from its own git integration, which is why this repo
-# has never had a deploy job. Cloudflare has no equivalent — Workers Builds
+# Netlify deployed itself from its own git integration, which is why this repo
+# had no deploy job for years. Cloudflare has no equivalent — Workers Builds
 # exists, but its monorepo handling has a known flakiness report for workspace
 # dependency resolution and nothing authoritative for Bun, and this repo has
 # cross-package build ordering (roller -> rdn) that CI already sequences
 # correctly. So deployment lives here, where the build is already known-good.
 #
-# Path-filtered per site rather than deploying everything on every merge, which
-# is the same economy the netlify.toml `ignore` predicates were buying.
+# Path-filtered per surface rather than deploying everything on every merge,
+# which is the same economy the netlify.toml `ignore` predicates were buying.
 #
-# Both jobs SKIP rather than fail when CLOUDFLARE_API_TOKEN is absent. That is
-# the state of the world until the secret is added, and a workflow that fails
-# red on every merge for a known, documented, expected reason is worse than one
-# that does nothing: it trains people to ignore a failing check, and the next
-# real failure hides inside the noise. Adding the secret enables deploys with no
-# further change here.
+# Every job SKIPS rather than fails when CLOUDFLARE_API_TOKEN is absent. A
+# workflow that fails red on every merge for a known, documented, expected
+# reason is worse than one that does nothing: it trains people to ignore a
+# failing check, and the next real failure hides inside the noise.
+#
+# NOTE the asymmetry, because it decides how bad a missed deploy is. The two
+# sites are live on Cloudflare and the Netlify projects are kept only as a
+# rollback, so a skipped site deploy means randsum.dev silently serves stale
+# content. The bot is stricter still: Discord posts interactions to
+# bot.randsum.dev and there is no second transport behind it any more, so the
+# deployed Worker IS the bot.
 name: Deploy (Cloudflare)
 
 on:
@@ -24,6 +29,7 @@ on:
     paths:
       - 'apps/rdn/**'
       - 'apps/site/**'
+      - 'apps/discord-bot/**'
       - 'packages/**'
       - 'bun.lock'
       - '.github/workflows/deploy-cloudflare.yml'
@@ -68,10 +74,10 @@ jobs:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - uses: ./.github/actions/bun-setup
 
-      # DEPLOY_TARGET selects the Astro adapter. Astro allows exactly one, and
-      # Netlify is still serving randsum.dev, so the config defaults to Netlify
-      # and only this job opts into Cloudflare. Both targets are buildable from
-      # the same commit until the cutover.
+      # DEPLOY_TARGET is now the config's own default, so this is belt and
+      # braces rather than an opt-in. It stays set explicitly because this job
+      # must never build for Netlify, and that should not depend on a default
+      # someone could reasonably change back while the switch still exists.
       - name: Build
         env:
           DEPLOY_TARGET: cloudflare
@@ -90,7 +96,32 @@ jobs:
         run: |
           if [ -z "$CLOUDFLARE_API_TOKEN" ]; then
             echo "::notice::CLOUDFLARE_API_TOKEN is not set — skipping deploy."
-            echo "Add the secret to enable Cloudflare deploys. Netlify is unaffected."
+            echo "randsum.dev will keep serving the previously deployed version."
             exit 0
           fi
           bunx wrangler@4 deploy -c apps/site/dist/server/wrangler.json
+
+  bot:
+    name: bot.randsum.dev
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - uses: ./.github/actions/bun-setup
+
+      # The game packages must be built first: the Worker imports them through
+      # workspace subpath exports, and wrangler bundles from dist. Unlike the
+      # sites there is no separate app build step — wrangler compiles the
+      # TypeScript entry itself.
+      - name: Build dependencies
+        run: bun run --filter '@randsum/roller' --filter '@randsum/games' build
+
+      - name: Deploy
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+        run: |
+          if [ -z "$CLOUDFLARE_API_TOKEN" ]; then
+            echo "::notice::CLOUDFLARE_API_TOKEN is not set — skipping deploy."
+            echo "The bot keeps serving the previously deployed Worker."
+            exit 0
+          fi
+          bunx wrangler@4 deploy -c apps/discord-bot/wrangler.jsonc

--- a/apps/DEPLOY.md
+++ b/apps/DEPLOY.md
@@ -12,7 +12,7 @@ to file incident RCAs.
 | ------------------ | ----------------------------------------------- | ------------------- | ------------------------ | --------------------- |
 | Docs site          | `apps/site`                                     | **Cloudflare**      | push to `main`           | randsum.dev           |
 | Notation spec site | `apps/rdn`                                      | **Cloudflare**      | push to `main`           | notation.randsum.dev  |
-| Discord bot        | `apps/discord-bot`                              | Render (worker)     | manual / Render redeploy | n/a (Discord gateway) |
+| Discord bot        | `apps/discord-bot`                              | **Cloudflare**      | push to `main`           | bot.randsum.dev       |
 | npm packages       | `packages/roller`, `packages/games`, `apps/cli` | npm registry        | changesets on merge      | npmjs.com/org/randsum |
 
 **Both sites migrated to Cloudflare on 2026-08-18.** DNS for `randsum.dev` is on
@@ -36,14 +36,23 @@ as a Worker route on the apex.
 
 ## Cloudflare cutover — the four manual steps
 
-> **Status: in progress.** All the code has shipped. Both sites build for
-> Cloudflare, CI deploys them on merge, and the Discord bot has a working
-> HTTP-interactions Worker. **Netlify and Render still serve everything** — that
-> is deliberate, and nothing user-facing has changed.
+> **Status: done — all three surfaces serve from Cloudflare as of 2026-08-18.**
+> Both sites and the Discord bot were cut over on the same day. The steps below
+> are kept as the record of how it was done and how to verify it, not as
+> outstanding work.
 >
-> What remains cannot be done from a terminal. Everything below needs a browser
-> and account access. Each step has a verification you can run afterwards; do not
-> proceed past one that fails.
+> **What is left is decommissioning, which is deliberately not automatic.** The
+> Netlify projects and the Render worker still exist and still cost nothing to
+> keep. They are the rollback: while they exist, reverting a site is restoring
+> two A records, and reverting the bot is clearing one field in the Discord
+> application settings. Delete them only after a soak period, and delete Netlify
+> before Render — the sites have been verified far longer than the bot has.
+>
+> One thing genuinely does remain: `CLOUDFLARE_API_TOKEN` is **not** set as a
+> repository secret, so `deploy-cloudflare.yml` skips every job and merges to
+> `main` do not actually deploy. Until it is set, deploys are manual
+> (`wrangler deploy`). Prefer a token scoped to `Workers Scripts:Edit` +
+> `Workers Routes:Edit` + `Account Settings:Read` over an account-wide key.
 
 ### 1. Register a workers.dev subdomain · ~1 min
 
@@ -117,23 +126,46 @@ What still stands:
 - **Do it with someone watching.** Short TTLs make a mistake quick to *undo*,
   not impossible to *make*.
 
-> ⚠️ **This inventory is a probe, not a zone dump.** It was built with `dig`
-> against the names above plus the usual suspects; enumerating a zone requires
-> AXFR (refused) or the Netlify DNS dashboard. Before cutting over, open that
-> dashboard and diff it against this table — a record at a name nobody guessed
-> is exactly what this method cannot see.
+> ⚠️ **This inventory was a probe, not a zone dump** — it was built with `dig`
+> against the names above plus the usual suspects, because enumerating a zone
+> requires AXFR (refused) or the Netlify DNS dashboard.
+>
+> **Re-checked after the cutover, and it held.** The Netlify/NS1 zone is still
+> authoritative for its own copy, so it was queried directly for MX, TXT, CAA,
+> SRV and CNAME across the apex and fifteen candidate subdomains: it contains
+> exactly three names, all A records. The migration script replicated A records
+> only, which was therefore complete rather than lucky — worth stating, because
+> "we copied the A records" and "we copied everything" happened to coincide here
+> and would not on a zone carrying mail or domain-verification records.
 
 ### Only then: decommission
 
-Netlify and Render can be closed once both sites have served from Cloudflare for
-a week and the bot has been stable. **The Discord bot is a separate switch**:
-setting an Interactions Endpoint URL stops gateway delivery instantly and is
-mutually exclusive with the Render worker, so treat it as its own cutover with
-its own rollback (delete the URL to fall back to the gateway).
+**Not yet done, and that is the plan rather than an oversight.** Netlify and
+Render still exist. They cost nothing to keep and they are the rollback:
 
-Sentry was never enabled — `SENTRY_DSN` has never been set in production — so
-there is nothing to close there. Alerting now runs through a Discord webhook and
-a Healthchecks heartbeat instead; see `apps/discord-bot/CLAUDE.md`.
+| To revert | Do this | Time |
+| --- | --- | --- |
+| A site | Re-add the two Netlify A records for that hostname | ~1 min + TTL |
+| The bot | Clear the Interactions Endpoint URL in the Discord app | instant |
+
+Close Netlify first — the sites have been verified continuously since the DNS
+switch, whereas the bot cut over later the same day. Close Render only after the
+bot has been observed handling real traffic across a busy period.
+
+**The bot's rollback has a shelf life.** Clearing the endpoint URL restores
+gateway delivery only while a gateway process is actually running. Once the
+Render service is deleted, that fallback is gone and reverting means
+redeploying the worker first — which is fine, but it is a different-sized
+operation than clearing a field, so do not delete Render believing the one-field
+revert still exists.
+
+Sentry needs no decommissioning: it was never enabled in production, and the
+Worker does not import the error tracker at all. Alerting for the gateway bot
+ran through a Discord webhook and a Healthchecks heartbeat (see
+`apps/discord-bot/CLAUDE.md`); **the Worker inherits neither.** Cloudflare
+Workers Observability is enabled in `wrangler.jsonc` and is now the only place
+bot errors are visible — worth knowing before wondering why the heartbeat went
+quiet.
 
 ## Netlify (apps/site → randsum.dev, apps/rdn → notation.randsum.dev)
 

--- a/apps/discord-bot/CLAUDE.md
+++ b/apps/discord-bot/CLAUDE.md
@@ -121,11 +121,35 @@ reached its error paths only if `errorTracker.init` logged `enabled: true` for t
 
 ## Deployment
 
-Deploys to **Render** as a `worker` service via the repo-root `render.yaml` blueprint
-(`name: randsum-discord-bot`, `runtime: node`, `region: oregon`, `plan: starter`, `autoDeploy: true`).
+**The bot runs as a Cloudflare Worker on HTTP interactions. The gateway is no longer how
+interactions arrive.** Discord POSTs them to `https://bot.randsum.dev/`, configured as the
+application's Interactions Endpoint URL, and `.github/workflows/deploy-cloudflare.yml` deploys
+`apps/discord-bot/wrangler.jsonc` on merge to `main`.
 
-- `numInstances` MUST stay `1` — a Discord gateway worker holds a single connection; multiple
-  instances double-process events.
+The two transports are mutually exclusive — setting that URL is what stopped gateway delivery, and
+clearing it is what would start it again. Discord validates the endpoint before saving it (a signed
+PING must Pong, and a corrupted signature must be rejected), so a broken Worker cannot be
+configured, only an already-configured one can break.
+
+- `DISCORD_PUBLIC_KEY` is a committed `var`, not a secret — see the reasoning in `wrangler.jsonc`.
+- `bot.randsum.dev` is declared in `routes`, so a deploy cannot detach the hostname Discord calls.
+- The Worker needs **no** `DISCORD_TOKEN`. HTTP interactions are authenticated by request
+  signature, not by a bot session, so the most sensitive credential simply is not present.
+- The dispatcher does **not** defer. A dice roll is sub-millisecond against a 3-second deadline, so
+  it replies directly — no follow-up webhook, no interaction token to keep alive.
+
+### The gateway path is still here, and still builds
+
+`src/index.ts` and everything under `src/events/` remain the discord.js gateway bot. It is dormant,
+not dead: it is the rollback, and a rollback that does not compile is not a rollback. Keep both
+transports working until the Render service is actually deleted.
+
+Historically it deployed to **Render** as a `worker` service via the repo-root `render.yaml`
+blueprint (`name: randsum-discord-bot`, `runtime: node`, `region: oregon`, `plan: starter`). If it
+is ever brought back:
+
+- `numInstances` MUST stay `1` — a gateway worker holds a single connection; multiple instances
+  double-process events.
 - Build is scoped to the dependency subtree, not the full monorepo:
   `bun install --frozen-lockfile && bun run --filter @randsum/roller --filter @randsum/games --filter @randsum/discord-bot build`
 - Start: `node apps/discord-bot/dist/index.js`
@@ -133,6 +157,15 @@ Deploys to **Render** as a `worker` service via the repo-root `render.yaml` blue
   `DISCORD_CLIENT_ID`, `DISCORD_GUILD_ID` are `sync: false` (set in the dashboard, not committed).
 - The blueprint may not be auto-synced to the live service — if you edit it, also reconcile the
   Render dashboard env vars.
+
+### Slash command registration did NOT move
+
+Commands are registered against the application, not against a transport, so the existing global
+registrations kept working across the cutover untouched. The gateway bot reconciles them on
+startup; with it stopped, `bun run deploy-commands` is the way to push a changed command list.
+**Adding or renaming a command now requires that step explicitly** — nothing in the Worker path
+does it for you, and the Worker will answer an unregistered command's name with "Unknown command"
+only if Discord ever sends it, which it will not.
 
 ### Manual / local deployment workflow
 

--- a/apps/discord-bot/wrangler.jsonc
+++ b/apps/discord-bot/wrangler.jsonc
@@ -16,11 +16,40 @@
   // supports would make `wrangler dev` refuse to start, and local testing is
   // the only way to exercise this before Discord is pointed at it.
   "compatibility_date": "2026-07-13",
+  // Declared here rather than passed as `--domains` on the deploy command, so a
+  // deploy that forgets the flag cannot silently detach the hostname Discord is
+  // configured to call. Discord stores an absolute URL and never rediscovers
+  // it, so losing this domain takes the bot down with no failing deploy to
+  // point at.
+  //
+  // Owning the hostname also keeps the Discord side independent of the
+  // account's workers.dev subdomain, which is a Cloudflare account detail and
+  // not something Discord's config should depend on.
+  "routes": [
+    {
+      "pattern": "bot.randsum.dev",
+      "custom_domain": true
+    }
+  ],
   "observability": {
     "enabled": true
+  },
+  // DISCORD_PUBLIC_KEY is committed, deliberately, reversing what an earlier
+  // revision of this file argued.
+  //
+  // It is not a credential. It verifies Discord's signatures; it cannot produce
+  // one. Only Discord holds the private half, so publishing this lets nobody
+  // forge an interaction — the threat model is backwards from a token's.
+  //
+  // The reason to commit it rather than `wrangler secret put` it is that a
+  // secret makes the Worker un-reproducible from the repo: CI deploys keep
+  // working (secrets survive a deploy), so a missing key shows up only on a
+  // fresh environment, as every request 401ing with nothing in the diff to
+  // explain it. Committed, `wrangler deploy` from a clean checkout is complete.
+  //
+  // The tradeoff accepted: pointing this Worker at a different Discord app is
+  // now a code change. That is the better failure mode — it shows up in review.
+  "vars": {
+    "DISCORD_PUBLIC_KEY": "fa40a08dc912843e0082cfc56ff312bfc6e20cf5306976871c16c14c72cbef11"
   }
-  // DISCORD_PUBLIC_KEY is intentionally absent. It is not a secret — it is the
-  // application's public key — but it is environment-specific, so it is set via
-  // `wrangler secret put` / the dashboard rather than committed. With it unset
-  // the Worker rejects every request, which is the correct failure direction.
 }

--- a/apps/site/astro.config.mjs
+++ b/apps/site/astro.config.mjs
@@ -19,12 +19,18 @@ const __dirname = fileURLToPath(new URL('.', import.meta.url))
 const isDev = process.argv.includes('dev')
 
 // Which host this build targets. Astro allows exactly one adapter, so during
-// the Cloudflare migration this has to be selectable rather than swapped:
-// flipping it outright would break the Netlify deploy that is still serving
-// randsum.dev, before the Cloudflare one has been proven. Netlify stays the
-// default so nothing changes until a build explicitly opts in, and the eventual
-// cutover is a one-line change here plus deleting the loser.
-const deployTarget = process.env.DEPLOY_TARGET ?? 'netlify'
+// the migration this had to be selectable rather than swapped.
+//
+// Cloudflare is now the default, because it is what actually serves
+// randsum.dev. A default that disagrees with production is a trap: `bun run
+// build` locally would produce a Netlify build, and every difference between
+// the two adapters would go unnoticed until a deploy.
+//
+// Netlify remains reachable via DEPLOY_TARGET=netlify, deliberately. The
+// Netlify project still exists as the rollback, and a rollback nobody can build
+// for is not a rollback. Remove this switch — and @astrojs/netlify — when the
+// Netlify project is deleted, not before.
+const deployTarget = process.env.DEPLOY_TARGET ?? 'cloudflare'
 
 function resolveAdapter() {
   if (isDev) return undefined
@@ -40,10 +46,10 @@ function resolveAdapter() {
     // markdown pipeline's `require('path')`.
     //
     // Shiki can be pointed at a pure-JavaScript regex engine instead, and that
-    // also works — but it changes how code is highlighted, on a site that is
-    // live and currently served from Netlify. Prerendering in Node changes
-    // nothing about the output at all: it is the same environment the Netlify
-    // build already uses, so the two targets produce the same pages.
+    // also works — but it changes how code is highlighted, on a live site.
+    // Prerendering in Node changes nothing about the output at all: it is the
+    // same environment the Netlify build used, so the two targets produce
+    // identical pages. That equivalence is what made the cutover verifiable.
     prerenderEnvironment: 'node'
   })
 }


### PR DESCRIPTION
**The bot is live on Cloudflare.** It now receives interactions over HTTP at `bot.randsum.dev` instead of over the Discord gateway. Setting the application's Interactions Endpoint URL is what stopped gateway delivery — the two transports are mutually exclusive, so **this was the switch, not a preparation for it.**

## How it was verified before flipping

Discord validates an endpoint before it will save one: a signed PING must Pong, *and* a corrupted signature must be rejected. A broken Worker cannot be configured at all — so the save succeeding is a real verification, not an assertion.

Before that, the Worker was exercised end to end **inside workerd**, with a throwaway Ed25519 keypair so it needed no Discord credentials:

| Check | Result |
| --- | --- |
| Signed `PING` → `{type:1}` | ✅ |
| Corrupted signature → 401 | ✅ |
| Unsigned request → 401 | ✅ |
| `GET /` → 405 | ✅ |
| All 10 commands return a real embed | ✅ |
| `/notation` select menu → in-place `UpdateMessage` (7) | ✅ |
| Invalid notation → error embed, not a 500 | ✅ |

15/15. The command check specifically asserts the response is *not* the "not available on this deployment yet" placeholder — every command is genuinely ported, not merely routed.

## Decisions worth reviewing

**`bot.randsum.dev` is declared in `routes`,** not passed as `--domains` on the deploy command. Discord stores an absolute URL and never rediscovers it, so a deploy that forgot the flag would take the bot down with no failing deploy to point at.

**`DISCORD_PUBLIC_KEY` is committed as a `var`** — reversing what that file argued before. It *verifies* Discord's signatures and cannot produce one, so publishing it lets nobody forge an interaction; the threat model is backwards from a token's. Kept as a secret it made the Worker un-reproducible from the repo: CI deploys keep working (secrets survive a deploy), so a missing key surfaces only on a fresh environment, as every request 401ing with nothing in the diff to explain it.

**The Worker needs no `DISCORD_TOKEN` at all.** HTTP interactions authenticate by request signature, so the most sensitive credential is simply absent from this deployment.

**The Astro adapter now defaults to Cloudflare.** A default that disagrees with production is a trap — `bun run build` locally was still producing a Netlify build. `DEPLOY_TARGET=netlify` still works on purpose: the Netlify project is the rollback, and a rollback nobody can build for is not a rollback.

**The gateway path is left intact and building.** Dormant, not dead — it stays that way until the Render service is actually deleted.

## Two things this deliberately does NOT do

**1. Deploys still don't run automatically.** `CLOUDFLARE_API_TOKEN` is not set as a repository secret, so every job in `deploy-cloudflare.yml` skips and deploys remain manual. I did not set it: the only token available to me is **account-wide**, and CI should hold one scoped to `Workers Scripts:Edit` + `Workers Routes:Edit` + `Account Settings:Read`. That token can't be minted from the API (it lacks `User API Tokens:Edit`), so it needs the dashboard.

**2. Nothing is decommissioned.** Netlify and Render still exist, as the rollback:

| To revert | Do this | Time |
| --- | --- | --- |
| A site | Re-add the two Netlify A records | ~1 min + TTL |
| The bot | Clear the Interactions Endpoint URL | instant |

`DEPLOY.md` now records the non-obvious part: **the bot's one-field revert only works while a gateway process is still running.** Deleting the Render service doesn't remove the rollback, but it changes it from "clear a field" to "redeploy a worker first" — worth knowing before deleting it.

## Unrelated problem found

The Discord app's **Terms of Service and Privacy Policy URLs both 404.** They point at `apps/robo/`, and those files were deleted in `240930e1` ("Remove Robo") and never re-added. This predates the migration and affects a public bot on 19 servers. Not fixed here — restoring them is a call about legal text, not a deploy change. Old content is recoverable: `git show 240930e1^:packages/robo/TERMS_OF_SERVICE.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Qeum9i6jZtAHoziAZFHSsH
