### PR TITLE
fix(discord-bot): restore the privacy policy so its published URL stops 404ing

### DIFF
--- a/apps/discord-bot/PRIVACY_POLICY.md
+++ b/apps/discord-bot/PRIVACY_POLICY.md
@@ -1,0 +1,35 @@
+# Privacy Policy for RANDSUM.dev
+
+This Privacy Policy governs the collection, use, and sharing of personal information by RANDSUM.dev, a Discord bot developed by Alex Jarvis. By using RANDSUM.dev, you agree to the terms of this Privacy Policy.
+
+Information We Collect
+
+We collect information that you provide to us through your use of the bot, such as your Discord user ID and username, server and channel information, and message content. We may also collect usage data, such as the frequency and duration of your use of the bot.
+
+How We Use Your Information
+
+We use your information to operate and improve RANDSUM.dev, including to provide support and respond to your requests. We may also use your information to develop new features or services, to conduct research and analytics, and to comply with legal obligations.
+
+Sharing Your Information
+
+We do not sell or share your personal information with third parties. However, we may disclose your information in response to legal process or a request from a law enforcement agency or regulatory authority.
+
+Data Retention
+
+We retain your information for as long as necessary to provide RANDSUM.dev’s services or as required by law. We will delete your information upon your request or when it is no longer needed.
+
+Data Security
+
+We take reasonable measures to protect your information from unauthorized access, alteration, or destruction. However, no security measure is perfect, and we cannot guarantee the security of your information.
+
+Changes to this Policy
+
+We may update this Privacy Policy from time to time, and we will post the updated policy on our website. Your continued use of RANDSUM.dev after we make changes to this policy indicates your acceptance of the revised policy.
+
+Contact Us
+
+If you have any questions or concerns about this Privacy Policy, please contact us at Alxjrvs at gmail dot com.
+
+Effective Date
+
+This Privacy Policy is effective as of 2024-01-01.


### PR DESCRIPTION
The Discord application advertises a Privacy Policy URL pointing at `apps/robo/PRIVACY_POLICY.md`. That file was deleted in `240930e1` ("Remove Robo") and never re-added — so a **public bot installed on 19 servers has been linking to a 404** ever since.

Restored verbatim from `240930e1^`, at the path the app already expects under the current directory name. **Not edited**: this is the policy that was in force (effective 2024-01-01), and rewriting it is a legal decision rather than a code cleanup.

## Two things this deliberately does NOT fix

**1. The Terms of Service is still missing, and is not restored here.**

The archived copy has unfilled placeholders in its governing-law clause:

> This Agreement shall be governed by … the laws of **[Your country/state/province]**. Any dispute … resolved by arbitration in accordance with the rules of **[Your arbitration provider]**.

Republishing that verbatim would put literal blanks into live legal text that reads as authoritative — arguably worse than the 404 it replaces. Filling them means choosing a jurisdiction and an arbitration provider, which isn't a call to make on someone's behalf.

**Suggested interim:** clear the Terms of Service URL in the Discord application so it stops advertising a dead link. Discord doesn't require one for unverified apps, and no link beats a broken link. Re-add it once the two blanks are filled.

**2. The policy now over-describes what the bot collects.**

It says it collects "your Discord user ID and username, server and channel information, and message content." The Worker is **stateless** — it processes an interaction and replies, persisting none of that. So the wording over-discloses rather than under-discloses, which is the safe direction, but it no longer describes how the bot actually works. Tightening it is again a legal edit, not a mechanical one.

## After merge — the Discord app URL still needs updating

The app points at the **old** `apps/robo/` path, and the file is restored under `apps/discord-bot/`, so merging alone does not fix the 404. The Privacy Policy URL in the application settings has to change to:

```
https://raw.githubusercontent.com/RANDSUM/randsum/refs/heads/main/apps/discord-bot/PRIVACY_POLICY.md
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Qeum9i6jZtAHoziAZFHSsH
